### PR TITLE
[PROG-1256] Change status endpoint to healthz

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -570,7 +570,7 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("port", 8000)
 	v.SetDefault("admin_port", 6060)
 	v.SetDefault("enable_gzip", false)
-	v.SetDefault("status_response", "")
+	v.SetDefault("status_response", "OK")
 	v.SetDefault("auction_timeouts_ms.default", 0)
 	v.SetDefault("auction_timeouts_ms.max", 0)
 	v.SetDefault("cache.scheme", "")

--- a/router/router.go
+++ b/router/router.go
@@ -269,7 +269,7 @@ func New(cfg *config.Configuration, rateConvertor *currencies.RateConverter) (r 
 	r.GET("/info/bidders/:bidderName", infoEndpoints.NewBidderDetailsEndpoint(bidderInfos, defaultAliases))
 	r.GET("/bidders/params", NewJsonDirectoryServer(schemaDirectory, paramsValidator, defaultAliases))
 	r.POST("/cookie_sync", endpoints.NewCookieSyncEndpoint(syncers, cfg, gdprPerms, r.MetricsEngine, pbsAnalytics))
-	r.GET("/status", endpoints.NewStatusEndpoint(cfg.StatusResponse))
+	r.GET("/healthz", endpoints.NewStatusEndpoint(cfg.StatusResponse))
 	r.GET("/", serveIndex)
 	r.ServeFiles("/static/*filepath", http.Dir("static"))
 


### PR DESCRIPTION
## JIRA
[PROG-1256](https://jira.tapjoy.net/browse/PROG-1256)

## Description
This PR changes the `status` endpoint to `healthz` which is `tapjoy standard`. Also the default value is updated so that the endpoint responds with `"OK"`.
Please review: @eric-kansas, @jingniwei, @alanbrent

## How to test
- Run the tpe_prebid_service locally. Until merging [@jingniwei 's PR](https://github.com/Tapjoy/tpe_prebid_service/pull/3):
  - `go build`
  - `./prebid-server`
- Curl `healthz` endpoint
  - `curl "http://localhost:8000/healthz"`
- Confirm if you get `"OK"`response back
