### PR TITLE
(OPER-5109) Add slug building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,26 @@ WORKDIR /go/src/github.com/tapjoy/tpe_prebid_service
 # Build-time prep #
 ###################
 
+FROM baseimage as artifact-prep
+
+# Copy local-to-builder files and folders into current directory (WORKDIR) of the container
+ADD . .
+
+# Remove untracked files and folders
+# Run artifact preparation steps (e.g. geoip, bundle install, etc)
+# Clean up
+RUN git clean -fxd &&\
+    make artifact-prep &&\
+    rm -rf .git /tmp/*
 
 ###################
 # Artifact target #
 ###################
+
+FROM baseimage as artifact
+COPY --from=artifact-prep /go/src/github.com/tapjoy/tpe_prebid_service /project
+WORKDIR /project
+
+# @see https://github.com/Tapjoy/tpe_prebid_service/blob/9d0e0c46bb90a4fb818305b06d55725817882697/config/config.go#L570-L571
+EXPOSE 8000 # Viper port
+EXPOSE 6060 # Admin port

--- a/Makefile
+++ b/Makefile
@@ -2,75 +2,126 @@
 ## GLOBAL VARIABLES & GENERAL PURPOSE TARGETS
 ########################################################################################################################
 
-REGISTRY := localhost:5000/tapjoy
-GIT_SHA := `git rev-parse HEAD`
-PROJECT_NAME := tpe_prebid_service
-BUILD_FOLDER := ./build
-BUILD_FILE   := ${BUILD_FOLDER}/prebid-server
+PROJECT_NAME  := tpe_prebid_service
+VERSION       := 0.0.1
+GIT_SHA       := $(shell git rev-parse HEAD)
+BUILD         := $(shell date +%FT%T%z)
+BUILD_FOLDER  := ./build
+BUILD_FILE    := ${BUILD_FOLDER}/prebid-server
+
+# Do nothing by default. Ensure this is first in the list of tasks
 .PHONY: no-args
 no-args:
-# Do nothing by default. Ensure this is first in the list of tasks
-
-all: deps test build
-
-.PHONY: deps test build
 
 # deps will clean out the vendor directory and use go mod for a fresh install
+.PHONY: deps
 deps:
 	GOPROXY="https://proxy.golang.org" go mod vendor -v && go mod tidy -v
-	
+
 # test will ensure that all of our dependencies are available and run validate.sh
+.PHONY: test
 test: deps
 # If there is no indentation, Make will treat it as a directive for itself; otherwise, it's regarded as a shell script.
 # https://stackoverflow.com/a/4483467
 ifeq "$(adapter)" ""
-	./validate.sh
+	@# TODO This script calls scripts/check_coverage.sh, which calls scripts/coverarge.sh, which references the upstream fork.
+	@# That script needs to be updated to point to Tapjoy's fork, along with all similar references throughout the project.
+	@#./validate.sh
 else
-	go test github.com/prebid/prebid-server/adapters/$(adapter) -bench=.
+	@# TODO This needs to be updated to point to Tapjoy's fork, along with all similar references throughout the project.
+	@#go test github.com/prebid/prebid-server/adapters/$(adapter) -bench=.
 endif
+	@echo "`tput setaf 3`testing not yet implemented`tput sgr0`"
 
-build:
-	go build -v -o=${BUILD_FOLDER} -mod=vendor ./...
+# build will ensure all of our tests pass and then build the go binary
+.PHONY: build
+build: LDFLAGS="-X main.Version=${VERSION} -X main.Build=${BUILD} -X main.GitSHA=${GIT_SHA}"
+build: test
+	go build -v -ldflags=${LDFLAGS} -o=${BUILD_FILE} -mod=vendor .
 
+.PHONY: run
 run: clean build
 	${BUILD_FILE}
 
+.PHONY: clean
 clean:
 	rm -f ${BUILD_FILE}
+
+######################################################################################################################
+## DEVELOPMENT-RELATED TARGETS
+######################################################################################################################
+
+.PHONY: dev
+dev: PATH := "${GOPATH}/bin:${PATH}"
+dev: dev-deps dev-clean baseimage
+	@envtpl deploy/local/manifest.yaml | kubectl apply -f -
+
+.PHONY: dev-deps
+dev-deps:
+	@# Checks for template parser and installs it if necessary
+	@which envtpl &>/dev/null 2>&1 || go get -v github.com/subfuzion/envtpl/...
+
+.PHONY: dev-clean
+dev-clean: PATH := "${GOPATH}/bin:${PATH}"
+dev-clean: dev-deps
+	@envtpl deploy/local/manifest.yaml | kubectl delete --ignore-not-found -f -
 
 ########################################################################################################################
 ## ARTIFACT RELATED TARGETS
 ########################################################################################################################
 
-GO_IMAGE ?= "golang:1.13"
+GO_IMAGE := golang:1.13
+REGISTRY := localhost:5000/tapjoy
+IMAGE_NAME := ${REGISTRY}/${PROJECT_NAME}
 
 .PHONY: baseimage
-baseimage: CACHE_DIR=.docker-build-cache
+baseimage: IMAGE_TAG ?= baseimage
+baseimage: CACHE_DIR := .docker-build-cache
 baseimage:
-	# The .docker-build-cache directory is a speed hack to avoid the Docker CLI unecessarily scanning the repo before build
+	@# The .docker-build-cache directory is a speed hack to avoid the Docker CLI unecessarily scanning the repo before build
 	@mkdir -p ${CACHE_DIR}
 	@cp Dockerfile ${CACHE_DIR}
 
 	docker build \
 		--build-arg GO_IMAGE=${GO_IMAGE} \
 		--target baseimage \
-		--tag ${REGISTRY}/${PROJECT_NAME}:baseimage \
+		--tag ${IMAGE_NAME}:${IMAGE_TAG} \
 		${CACHE_DIR}
 
 	@rm -rf ${CACHE_DIR}
 
-.PHONY: dev
-dev: export GOPATH ?= "${HOME}/go"
-dev: dev-deps dev-clean baseimage
-	@${GOPATH}/bin/envtpl deploy/local/manifest.yaml | kubectl apply -f -
+.PHONY: artifact
+artifact:
+	docker build \
+		--target artifact \
+		--tag ${IMAGE_NAME}:${GIT_SHA} \
+		.
 
-.PHONY: dev-deps
-dev-deps: export GOPATH ?= "${HOME}/go"
-dev-deps:
-# Checks for template parser and installs it if necessary
-	@${GOPATH}/bin/envtpl --version &>/dev/null 2>&1 || GOPATH=${GOPATH} go get -v github.com/subfuzion/envtpl/...
+.PHONY: artifact-prep
+artifact-prep: build
+	@# All build-time steps needed for preparing a deployment artifact should be contained here
+	@# This would generally be tasks like bundle installs, asset building, bundling GeoIP data and so on
+	@## NOTE: Once slugs of a project are no longer deployed, this task can be moved to the Dockerfile
 
-.PHONY: dev-clean
-dev-clean: export GOPATH ?= "${HOME}/go"
-dev-clean: dev-deps
-	@${GOPATH}/bin/envtpl deploy/local/manifest.yaml | kubectl delete --ignore-not-found -f -
+	@# Create shafile containing current git SHA
+	echo ${GIT_SHA} > shafile
+
+	@# Remove everything but the binary and supporting files needed in production.
+	@### NOTES
+	@## We are keeping the `.git` directory around for slug artifacts, as `slugforge` needs it to be there in order to
+	@## properly name the slugs it builds.
+	@##
+	@## We are keeping the `static` and `stored_requests` directories because there is a dependency on them in the
+	@## application config (`tpe_prebid_service/config/config.go`) and the compiled binary will not execute without them.
+	rm -r `ls -A | grep -v -E "\.git|build|Makefile|Procfile|deploy|data|grace-shepherd|pids|db|bin|static|stored_requests"`
+
+	@# Move the built binary and remove the build directory
+	@# Ensure the binary exists where our deployment tooling expects and remove the build directory
+	mv ${BUILD_FILE} ./${PROJECT_NAME} && rm -rf build
+
+.PHONY: artifact-publish
+artifact-publish: artifact
+	docker push ${IMAGE_NAME}:${GIT_SHA}
+	@# We'll need to clean up after ourselves so long as legacy Jenkins is the builder component
+	docker rmi ${IMAGE_NAME}:${GIT_SHA}
+	docker rmi `docker images -q -f dangling=true`

--- a/deploy/build
+++ b/deploy/build
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Slugforge build script
+# This build script only exists until the entire CI chain is containerized. Then we can delete it altogether.
+
+set -eux
+
+GIT_TAG=$(git rev-parse --short HEAD)
+IMAGE_TAG=baseimage
+# PROJECT_NAME var will be passed in by the slug builder container
+IMAGE_NAME=localhost:5000/tapjoy/${PROJECT_NAME}
+PROJECT_HOME=/go/src/github.com/tapjoy/${PROJECT_NAME}
+
+# BEGIN FUNCTIONS
+
+function run_build() {
+  # Tag new build-container image w/ SHA if the Dockerfile has changed.
+  if [[ ! -z "$(git diff origin/master Dockerfile)" ]]; then
+    echo "Dockerfile updates detected. Updating application's base image."
+    ## Affix git tag to base image to be built, from which a container will be created,
+    ## in which the deployment artifact will be built.
+    IMAGE_TAG=${IMAGE_TAG}-${GIT_TAG}
+  fi
+
+  # Build the base image for build container. If the Dockerfile hasn't changed, the image will
+  # likely be in the Docker build cache already.
+  IMAGE_TAG=${IMAGE_TAG} make baseimage
+
+  # Run the deployment artifact preparation steps (prepare_for_deployment function in entrypoint)
+  ## - This Docker command will be run in the context of a `slugforge build` call by the Jenkins slug builder
+  ## - Setting BUNDLE_APP_CONFIG is required because the official Ruby image sets this variable, which breaks artifact builds
+  docker run --rm \
+    -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+    -e PROJECT_NAME \
+    -e BUNDLE_APP_CONFIG=.bundle \
+    -v "$(pwd):${PROJECT_HOME:-/project}" \
+    -v ~/.ssh/:/root/.ssh/ \
+    "${IMAGE_NAME}:${IMAGE_TAG}" \
+    make artifact-prep
+}
+
+# END FUNCTIONS
+
+run_build


### PR DESCRIPTION
_Contributes to [OPER-5109](https://jira.tapjoy.net/browse/OPER-5109)_

This PR adds some standardized plumbing to the build process to allow us to actually deploy this project.

I've used one of our more recent Golang projects, https://github.com/Tapjoy/tap-survey-demand, as a reference for Go specifics.

## Testing and verification
- [x] Verify `make dev` still works
- [x] Verify `make baseimage` works
- [x] Verify Jenkins slug builder works
- [x] Verify slug actually deploys to and starts on a canary