### PR TITLE
[PROG-1259] Enable rubicon video

### DIFF
--- a/static/bidder-info/rubicon.yaml
+++ b/static/bidder-info/rubicon.yaml
@@ -4,6 +4,7 @@ capabilities:
   app:
     mediaTypes:
       - banner
+      - video
   site:
     mediaTypes:
       - banner


### PR DESCRIPTION
## JIRA
[PROG-1259](https://jira.tapjoy.net/browse/PROG-1259)

## Description
This PR adds `video` to rubicon's config for app type requests (app is for mobile, site is for browser) to enable us to request video ads from rubicon.
Note that `adapters.rubicon.xapi.password`, `adapters.rubicon.xapi.username` and `adapters.rubicon.disabled` are also needed to be set, we're handling in chef config : https://github.com/Tapjoy/5rocks-chef/pull/2605

Please review: @eric-kansas 