### PR TITLE
[PROG-1273] AqID support

### DIFF
--- a/deploy/local/manifest.yaml
+++ b/deploy/local/manifest.yaml
@@ -77,6 +77,8 @@ data:
   PBS_MONITORING_NEWRELIC_APP_NAME: "tpe_prebid_service-dev"
   PBS_MONITORING_NEWRELIC_LICENSE_KEY: {{ default "ThisValueIs40CharacterNewRelicLicenseKey" (env "PBS_MONITORING_NEWRELIC_LICENSE_KEY") | quote }}
   PBS_MONITORING_NEWRELIC_LOG_LEVEL: "error" # // values: https://github.com/sirupsen/logrus/blob/39a5ad12948d094ddd5d5a6a4a4281f453d77562/logrus.go#L25
+
+  PBS_ADAPTERS_RUBICON_DISABLED: "false"
 ---
 ########################################################################################################################
 ## WORKLOAD-RELATED MANIFESTS
@@ -111,6 +113,17 @@ spec:
         port: {{$appPort}}
       initialDelaySeconds: 5
       periodSeconds: 5
+  - name: mock-service
+    image: localhost:5000/tapjoy/mock_service:latest
+    imagePullPolicy: IfNotPresent
+    env:
+    - name: "PORT"
+      value: "4646"
+    ports:
+    - containerPort: 4646
+    livenessProbe:
+      tcpSocket:
+        port: 4646
   volumes:
   - name: src
     persistentVolumeClaim:

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,8 @@ github.com/mssola/user_agent v0.4.1 h1:iTUaMpVrb2qWyvUw8UvK3ygWMd2lB1NGuZ1xhpBf1
 github.com/mssola/user_agent v0.4.1/go.mod h1:UFiKPVaShrJGW93n4uo8dpPdg1BSVpw2P9bneo0Mtp8=
 github.com/mxmCherry/openrtb v11.0.0+incompatible h1:tNzh7vKwQ8lopBAadyN3QPryawXSaVXYWi1IVluXHiM=
 github.com/mxmCherry/openrtb v11.0.0+incompatible/go.mod h1:zpnz6Au3bzTGplpRU0kvFPNT6g4ROAKx/GkrslFDwZk=
-github.com/newrelic/go-agent v3.4.0+incompatible h1:GhUhNLDdR3ETfUVJAN/czXlqRTcgbPs6U02jYhf15rg=
 github.com/newrelic/go-agent/v3 v3.0.0 h1:YK9ddXLcMoWr/Bqj30T+cQo1wniFVR5SS/mVuVTGKS8=
 github.com/newrelic/go-agent/v3 v3.0.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
-github.com/newrelic/go-agent/v3 v3.4.0 h1:PZTDUw+8h0yRkpkkXKrHSlRsDk0uYJ4I3Dv2lrws/EU=
 github.com/newrelic/go-agent/v3/integrations/nrhttprouter v1.0.0 h1:58+OKy9eBvASQoWKhTQNJjY/AWIcFZkpff2JNpLLn9o=
 github.com/newrelic/go-agent/v3/integrations/nrhttprouter v1.0.0/go.mod h1:CkLa4BKOGaiFbWHsv7zOspG+zXrfjsNXDxsDGvdhT+s=
 github.com/newrelic/go-agent/v3/integrations/nrlogrus v1.0.0 h1:qmAtZBKzuzxTkcBBfWHbeImk0Wxjooc522xaafANKJs=


### PR DESCRIPTION
## JIRA
[PROG-1273](https://jira.tapjoy.net/browse/PROG-1273)

## Description
This PR adds support for AqID field coming in rubicon response. Rubicon returns this value, but because openrtb2.5 BidResponse object doesn't have this field, it disappears when Unmarshalling rubicon response into openrtb2.5 BidResponse. With this PR, we unmarshal the response into our custom rubicon struct to extract aqid, then inject the aqid into bid.ext object.
Please review: @eric-kansas 

## How to test
Please see [ad_service PR](https://github.com/Tapjoy/ad_service/pull/555)

## Related PRs
- [ad_service PR](https://github.com/Tapjoy/ad_service/pull/555)
- [go-prebid PR](https://github.com/Tapjoy/go-prebid/pull/4)

## Pre Deploy
- [ ] Deploy [go-prebid PR](https://github.com/Tapjoy/go-prebid/pull/4)
- [ ] Release a new version of go-prebid shared package
- [ ] Add version bump to the [ad_service PR](https://github.com/Tapjoy/ad_service/pull/555) and deploy it