### PR TITLE
[PROG-1273] Viewability vendors support

### DIFF
--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -69,7 +69,8 @@ type rubiconImpExtRP struct {
 }
 
 type rubiconImpExt struct {
-	RP rubiconImpExtRP `json:"rp"`
+	RP                 rubiconImpExtRP `json:"rp"`
+	ViewabilityVendors []string        `json:"viewabilityvendors"`
 }
 
 type rubiconUserExtRP struct {
@@ -684,6 +685,7 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 				Target: target,
 				Track:  rubiconImpExtRPTrack{Mint: "", MintVersion: ""},
 			},
+			ViewabilityVendors: rubiconExt.ViewabilityVendors,
 		}
 		thisImp.Ext, err = json.Marshal(&impExt)
 		if err != nil {

--- a/openrtb_ext/imp_rubicon.go
+++ b/openrtb_ext/imp_rubicon.go
@@ -6,13 +6,14 @@ import (
 
 // ExtImpRubicon defines the contract for bidrequest.imp[i].ext.rubicon
 type ExtImpRubicon struct {
-	AccountId int                `json:"accountId"`
-	SiteId    int                `json:"siteId"`
-	ZoneId    int                `json:"zoneId"`
-	Inventory json.RawMessage    `json:"inventory,omitempty"`
-	Visitor   json.RawMessage    `json:"visitor,omitempty"`
-	Video     rubiconVideoParams `json:"video"`
-	Region    string             `json:"region"`
+	AccountId          int                `json:"accountId"`
+	SiteId             int                `json:"siteId"`
+	ZoneId             int                `json:"zoneId"`
+	Inventory          json.RawMessage    `json:"inventory,omitempty"`
+	Visitor            json.RawMessage    `json:"visitor,omitempty"`
+	Video              rubiconVideoParams `json:"video"`
+	Region             string             `json:"region"`
+	ViewabilityVendors []string           `json:"viewabilityvendors"`
 }
 
 // rubiconVideoParams defines the contract for bidrequest.imp[i].ext.rubicon.video


### PR DESCRIPTION
## JIRA
[PROG-1273](https://jira.tapjoy.net/browse/PROG-1273)

## Description
This PR adds support for:
- req.imp[0].ext.viewabilityvendors (e.g. "moat.com")
- req.imp[0].ext.rp.target.moat_certified (true/false)
- req.imp[0].ext.rp.target.SDKVersion (e.g. "13.3.1")
Please review: @eric-kansas 

## How to test
See [ad_service PR](https://github.com/Tapjoy/ad_service/pull/557)

## Related PRs
- [ad_service PR](https://github.com/Tapjoy/ad_service/pull/557)
- [go-prebid PR](https://github.com/Tapjoy/go-prebid/pull/6)

## Pre-Deploy
- [ ] Deploy [go-prebid PR](https://github.com/Tapjoy/go-prebid/pull/6)
- [ ] Release a new version of go-prebid shared package
- [ ] bump the go-prebid version that supports viewability vendors, the reason for compilation errors is this