### PR TITLE
[PROG-1287] NewRelic error reporting

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -574,7 +574,7 @@ func TestPanicRecovery(t *testing.T) {
 	theMetrics := pbsmetrics.NewMetrics(metrics.NewRegistry(), openrtb_ext.BidderList(), config.DisabledMetrics{})
 	e := NewExchange(&http.Client{}, nil, cfg, theMetrics, adapters.ParseBidderInfos(cfg.Adapters, "../static/bidder-info", openrtb_ext.BidderList()), gdpr.AlwaysAllow{}, currencies.NewRateConverterDefault()).(*exchange)
 	chBids := make(chan *bidResponseWrapper, 1)
-	panicker := func(aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels, conversions currencies.Conversions) {
+	panicker := func(ctx context.Context, aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels, conversions currencies.Conversions) {
 		panic("panic!")
 	}
 	recovered := e.recoverSafely(panicker, chBids)
@@ -587,7 +587,7 @@ func TestPanicRecovery(t *testing.T) {
 		CookieFlag:  pbsmetrics.CookieFlagYes,
 		AdapterBids: pbsmetrics.AdapterBidNone,
 	}
-	recovered(openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, nil, &apnLabels, nil)
+	recovered(context.Background(), openrtb_ext.BidderAppnexus, openrtb_ext.BidderAppnexus, nil, &apnLabels, nil)
 }
 
 func buildImpExt(t *testing.T, jsonFilename string) json.RawMessage {

--- a/monitoring/newrelic/newrelic.go
+++ b/monitoring/newrelic/newrelic.go
@@ -1,7 +1,10 @@
 package newrelic
 
 import (
+	"context"
 	"net/http"
+
+	"github.com/golang/glog"
 
 	"github.com/newrelic/go-agent/v3/integrations/nrlogrus"
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -23,6 +26,23 @@ func Make(cfg config.NewRelic) (*newrelic.Application, error) {
 		nrlogrus.ConfigLogger(l),
 		ConfigIgnoreStatusCodes([]int{http.StatusUnprocessableEntity, http.StatusBadGateway}),
 	)
+}
+
+// NoticeError ...
+func NoticeError(ctx context.Context, err error) {
+	// get newrelic transaction from context
+	if ctx == nil {
+		glog.Warningf("Context is nil, could not notice error: %v", err)
+		return
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		glog.Warningf("Newrelic transaction is nil, could not notice error: %v", err)
+		return
+	}
+
+	txn.NoticeError(err)
 }
 
 func getLogger(logLevel string) (*logrus.Logger, error) {


### PR DESCRIPTION
## JIRA
[PROG-1287](https://jira.tapjoy.net/browse/PROG-1287)

## Description
This PR adds NewRelic error reporting functionality to tpe_prebid_service project. Also, recovering from panic is also added.
Please review: @eric-kansas 

## How this has been tested?
- Update manifest
  - PBS_MONITORING_NEWRELIC_LICENSE_KEY: {{ default "bb8353602ba48d962a5db59ac4e1468d2da7fb8d" (env "PBS_MONITORING_NEWRELIC_LICENSE_KEY") | quote }}
  - PBS_ADAPTERS_RUBICON_XAPI_USERNAME: "tapjoy"
  - PBS_ADAPTERS_RUBICON_XAPI_PASSWORD: "QD054DGVKH"
- insert nil pointer bugs or make some functions return error in the code to confirm if they are handled correctly and reported to NewRelic
- make dev
- forward ports
  - kubectl port-forward tpe-prebid-service 8000
- run postman request `http://localhost:8000/openrtb2/auction`
- check logs and NR dashboard