### PR TITLE
[NO-JIRA] Support HEAD requests for healthz

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -295,6 +295,7 @@ func New(cfg *config.Configuration, rateConvertor *currencies.RateConverter) (r 
 	r.GET("/bidders/params", NewJsonDirectoryServer(schemaDirectory, paramsValidator, defaultAliases))
 	r.POST("/cookie_sync", endpoints.NewCookieSyncEndpoint(syncers, cfg, gdprPerms, r.MetricsEngine, pbsAnalytics))
 	r.GET("/healthz", endpoints.NewStatusEndpoint(cfg.StatusResponse))
+	r.HEAD("/healthz", endpoints.NewStatusEndpoint(cfg.StatusResponse))
 	r.GET("/", serveIndex)
 	r.ServeFiles("/static/*filepath", http.Dir("static"))
 


### PR DESCRIPTION
## JIRA
NO-JIRA

## Description
This PR is to fix `Method Not Allowed` errors for HEAD health checks, which started to be reported after this change : https://github.com/Tapjoy/5rocks-chef/pull/2703
Although @alanbrent told that it's not super required, I missed the good old days of tpe_prebid_service where error rate is ~0%, so I decided to add this support.

## How to Test
- pull the branch
- spin up k8s tpe-prebid-service pod
```
curl -i -X HEAD http://tpe-prebid-service.default.svc.cluster.local/healthz
```
This should return HTTP 200, with OK message.