### PR TITLE
[NO-JIRA] Moloco bid id

### DIFF
--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -226,7 +226,7 @@ func (adapter *MolocoAdapter) MakeBids(_ *openrtb.BidRequest, externalRequest *a
 		for _, b := range sb.Bid {
 			if b.Price != 0 {
 				// copy response.bidid to openrtb_response.seatbid.bid.bidid
-				if b.ID == "0" {
+				if b.ID == "1" {
 					b.ID = bidResp.BidID
 				}
 


### PR DESCRIPTION
## JIRA
NO-JIRA

## Description
This PR is to set bid_id in the response->seatbid->bid object to response id if it's 1. Moloco is sending bid_id = 1 always, to be able to distinguish different bids, we're doing this.