### PR TITLE
[NO-JIRA] SKAN downcase trouble

### DIFF
--- a/adapters/crossinstall/crossinstall.go
+++ b/adapters/crossinstall/crossinstall.go
@@ -21,6 +21,7 @@ const (
 	USWest Region = "us_west"
 )
 
+// SKAN IDs must be lower case
 var crossinstallSKADNetIDs = map[string]bool{
 	"prcb7njmu6.skadnetwork": true,
 }

--- a/adapters/liftoff/liftoff.go
+++ b/adapters/liftoff/liftoff.go
@@ -31,6 +31,7 @@ const (
 	Vertical   Orientation = "v"
 )
 
+// SKAN IDs must be lower case
 var liftoffSKADNetIDs = map[string]bool{
 	"7ug5zh24hu.skadnetwork": true,
 }

--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -22,6 +22,7 @@ const (
 	APAC   Region = "apac"
 )
 
+// SKAN IDs must be lower case
 var molocoSKADNetIDs = map[string]bool{
 	"9t245vhmpl.skadnetwork": true,
 }

--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
@@ -201,7 +202,7 @@ func FilterPrebidSKADNExt(prebidExt *openrtb_ext.ExtImpPrebid, filterMap map[str
 // returns a subset elements of arr whose keys were in filterMap
 func filterArrayWithMap(arr []string, filterMap map[string]bool) (ret []string) {
 	for _, id := range arr {
-		if _, ok := filterMap[id]; ok {
+		if _, ok := filterMap[strings.ToLower(id)]; ok {
 			ret = append(ret, id)
 		}
 	}

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -33,6 +33,7 @@ const (
 	badvLimitSize = 50
 )
 
+// SKAN IDs must be lower case
 var rubiconSKADNetIDs = map[string]bool{
 	"abc": true,
 }

--- a/adapters/taurusx/taurusx.go
+++ b/adapters/taurusx/taurusx.go
@@ -22,6 +22,7 @@ const (
 	SG     Region = "sg"
 )
 
+// SKAN IDs must be lower case
 var taurusxExtSKADNetIDs = map[string]bool{
 	"22mmun2rn5.skadnetwork": true,
 }


### PR DESCRIPTION
## JIRA
NO-JIRA

## Description
This PR is to update filtering logic by using downcased version of the IDs. Originally, it was assumed that the incoming SKAN ID list is already lowercased but it was figured out that it's not the case. So filtering logic wasn't working properly. Comparison must be done by lowercasing the SKAN ID, and the original value in the list should be passed.