### PR TITLE
[NO-JIRA] Don't send SKAN when empty

### DIFF
--- a/adapters/crossinstall/crossinstall.go
+++ b/adapters/crossinstall/crossinstall.go
@@ -27,8 +27,8 @@ var crossinstallSKADNetIDs = map[string]bool{
 }
 
 type crossinstallImpExt struct {
-	Reward int               `json:"reward"`
-	SKADN  openrtb_ext.SKADN `json:"skadn,omitempty"`
+	Reward int                `json:"reward"`
+	SKADN  *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 type crossinstallBannerExt struct {
@@ -148,7 +148,7 @@ func (adapter *CrossInstallAdapter) MakeRequests(request *openrtb.BidRequest, _ 
 		if crossinstallExt.SKADNSupported {
 			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, crossinstallSKADNetIDs)
 			if len(skadn.SKADNetIDs) > 0 {
-				impExt.SKADN = skadn
+				impExt.SKADN = &skadn
 			}
 		}
 

--- a/adapters/crossinstall/crossinstalltest/exemplary/endpoint_empty.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/endpoint_empty.json
@@ -34,12 +34,7 @@
         },
         "ext": {
           "bidder": {
-            "reward": 1,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            }
+            "reward": 1
           }
         }
       }
@@ -54,12 +49,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 1
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/crossinstall/crossinstalltest/exemplary/endpoint_not_supported.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/endpoint_not_supported.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "reward": 1,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "region": "not_supported"
           }
         }
@@ -55,12 +50,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 1
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/crossinstall/crossinstalltest/exemplary/endpoint_us_east.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/endpoint_us_east.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "reward": 1,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "region": "us_east"
           }
         }
@@ -55,12 +50,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 1
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/crossinstall/crossinstalltest/exemplary/endpoint_us_west.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/endpoint_us_west.json
@@ -35,11 +35,7 @@
         "ext": {
           "bidder": {
             "reward": 1,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
+
             "region": "us_west"
           }
         }
@@ -55,12 +51,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 1
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/crossinstall/crossinstalltest/exemplary/video_interstitial.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/video_interstitial.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "reward": 0,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "region": "us_east"
           }
         }
@@ -55,12 +50,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 0
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/crossinstall/crossinstalltest/exemplary/video_rewarded.json
+++ b/adapters/crossinstall/crossinstalltest/exemplary/video_rewarded.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "reward": 1,
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "region": "us_east"
           }
         }
@@ -55,12 +50,7 @@
           "imp": [
             {
               "ext": {
-                "reward": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "reward": 1
               },
               "id": "test-imp-id",
               "video": {

--- a/adapters/liftoff/liftoff.go
+++ b/adapters/liftoff/liftoff.go
@@ -65,8 +65,8 @@ type liftoffBannerExt struct {
 }
 
 type liftoffImpExt struct {
-	Rewarded int               `json:"rewarded"`
-	SKADN    openrtb_ext.SKADN `json:"skadn,omitempty"`
+	Rewarded int                `json:"rewarded"`
+	SKADN    *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 type liftoffAppExt struct {
@@ -203,7 +203,7 @@ func (a *LiftoffAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 		if liftoffExt.SKADNSupported {
 			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, liftoffSKADNetIDs)
 			if len(skadn.SKADNetIDs) > 0 {
-				impExt.SKADN = skadn
+				impExt.SKADN = &skadn
 			}
 		}
 

--- a/adapters/liftoff/liftofftest/exemplary/endpoint_apac.json
+++ b/adapters/liftoff/liftofftest/exemplary/endpoint_apac.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "apac",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/endpoint_empty.json
+++ b/adapters/liftoff/liftofftest/exemplary/endpoint_empty.json
@@ -33,11 +33,6 @@
           ]
         },
         "ext": {
-          "skadn": {
-            "skadnetids": null,
-            "sourceapp": "",
-            "version": ""
-          },
           "bidder": {
             "video": {
               "skip": 1,
@@ -94,12 +89,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/endpoint_eu.json
+++ b/adapters/liftoff/liftofftest/exemplary/endpoint_eu.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "eu",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/endpoint_not_supported.json
+++ b/adapters/liftoff/liftofftest/exemplary/endpoint_not_supported.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "not_supported",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/endpoint_us_east.json
+++ b/adapters/liftoff/liftofftest/exemplary/endpoint_us_east.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/orientation_horizontal.json
+++ b/adapters/liftoff/liftofftest/exemplary/orientation_horizontal.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/orientation_vertical.json
+++ b/adapters/liftoff/liftofftest/exemplary/orientation_vertical.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/video_interstitial.json
+++ b/adapters/liftoff/liftofftest/exemplary/video_interstitial.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 1,
               "skipdelay": 5,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 0,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 0
               }
             }
           ]

--- a/adapters/liftoff/liftofftest/exemplary/video_rewarded.json
+++ b/adapters/liftoff/liftofftest/exemplary/video_rewarded.json
@@ -35,11 +35,6 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "skadn": {
-              "skadnetids": null,
-              "sourceapp": "",
-              "version": ""
-            },
             "video": {
               "skip": 0,
               "skipdelay": 0,
@@ -95,12 +90,7 @@
                 }
               },
               "ext": {
-                "rewarded": 1,
-                "skadn": {
-                  "skadnetids": null,
-                  "sourceapp": "",
-                  "version": ""
-                }
+                "rewarded": 1
               }
             }
           ]

--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -36,7 +36,7 @@ type molocoBannerExt struct {
 }
 
 type molocoImpExt struct {
-	SKADN openrtb_ext.SKADN `json:"skadn,omitempty"`
+	SKADN *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 // MolocoAdapter ...
@@ -173,7 +173,7 @@ func (adapter *MolocoAdapter) MakeRequests(request *openrtb.BidRequest, _ *adapt
 		if molocoExt.SKADNSupported {
 			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, molocoSKADNetIDs)
 			if len(skadn.SKADNetIDs) > 0 {
-				impExt.SKADN = skadn
+				impExt.SKADN = &skadn
 			}
 		}
 

--- a/adapters/moloco/molocotest/exemplary/endpoint_apac.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_apac.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/endpoint_empty.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_empty.json
@@ -48,13 +48,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/endpoint_eu.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_eu.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/endpoint_not_supported.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_not_supported.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/endpoint_us_east.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_us_east.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/video_interstitial.json
+++ b/adapters/moloco/molocotest/exemplary/video_interstitial.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/moloco/molocotest/exemplary/video_rewarded.json
+++ b/adapters/moloco/molocotest/exemplary/video_rewarded.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -96,9 +96,9 @@ type rubiconImpExtRP struct {
 }
 
 type rubiconImpExt struct {
-	RP                 rubiconImpExtRP   `json:"rp"`
-	ViewabilityVendors []string          `json:"viewabilityvendors"`
-	SKADN              openrtb_ext.SKADN `json:"skadn,omitempty"`
+	RP                 rubiconImpExtRP    `json:"rp"`
+	ViewabilityVendors []string           `json:"viewabilityvendors"`
+	SKADN              *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 type rubiconUserExtRP struct {
@@ -737,7 +737,7 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, rubiconSKADNetIDs)
 			// only add if present
 			if len(skadn.SKADNetIDs) > 0 {
-				impExt.SKADN = skadn
+				impExt.SKADN = &skadn
 			}
 		}
 

--- a/adapters/taurusx/taurusx.go
+++ b/adapters/taurusx/taurusx.go
@@ -36,7 +36,7 @@ type taurusxBannerExt struct {
 }
 
 type taurusxImpExt struct {
-	SKADN openrtb_ext.SKADN `json:"skadn,omitempty"`
+	SKADN *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 // TaurusXAdapter ...
@@ -155,7 +155,7 @@ func (adapter *TaurusXAdapter) MakeRequests(request *openrtb.BidRequest, _ *adap
 			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, taurusxExtSKADNetIDs)
 			// only add if present
 			if len(skadn.SKADNetIDs) > 0 {
-				impExt.SKADN = skadn
+				impExt.SKADN = &skadn
 			}
 		}
 

--- a/adapters/taurusx/taurusxtest/exemplary/endpoint_jp.json
+++ b/adapters/taurusx/taurusxtest/exemplary/endpoint_jp.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/taurusx/taurusxtest/exemplary/endpoint_not_supported.json
+++ b/adapters/taurusx/taurusxtest/exemplary/endpoint_not_supported.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/taurusx/taurusxtest/exemplary/endpoint_sg.json
+++ b/adapters/taurusx/taurusxtest/exemplary/endpoint_sg.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/taurusx/taurusxtest/exemplary/endpoint_us_east.json
+++ b/adapters/taurusx/taurusxtest/exemplary/endpoint_us_east.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/taurusx/taurusxtest/exemplary/video_interstitial.json
+++ b/adapters/taurusx/taurusxtest/exemplary/video_interstitial.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/adapters/taurusx/taurusxtest/exemplary/video_rewarded.json
+++ b/adapters/taurusx/taurusxtest/exemplary/video_rewarded.json
@@ -49,13 +49,7 @@
           "id": "test-request-id",
           "imp": [
             {
-              "ext": {
-                "skadn": {
-                  "skadnetids": null,
-                   "sourceapp": "",
-                   "version": ""
-                }
-              },
+              "ext": {},
               "id": "test-imp-id",
               "video": {
                 "mimes": [

--- a/openrtb_ext/imp.go
+++ b/openrtb_ext/imp.go
@@ -39,7 +39,7 @@ type ExtStoredRequest struct {
 
 // SKADN ..
 type SKADN struct {
-	Version    string   `json:"version"`
-	SourceApp  string   `json:"sourceapp"`
-	SKADNetIDs []string `json:"skadnetids"`
+	Version    string   `json:"version,omitempty"`
+	SourceApp  string   `json:"sourceapp,omitempty"`
+	SKADNetIDs []string `json:"skadnetids,omitempty"`
 }


### PR DESCRIPTION
## JIRA
No-JIRA

## Description
This PR is to fix not sending SKAN when it's empty. We needed to use pointer to exclude it from the impression object when it's empty.

## How to test
Tested in k8s, confirmed it works with the change. Enable SKAN in ad_service, put CrossInstall's SKAN id in the prebid request, fire it. Check logs on tpe_prebid_service side.