### PR TITLE
[TPE-37] Custom close button disable support for banner

### DIFF
--- a/adapters/crossinstall/crossinstall.go
+++ b/adapters/crossinstall/crossinstall.go
@@ -32,7 +32,8 @@ type crossinstallImpExt struct {
 }
 
 type crossinstallBannerExt struct {
-	PlacementType adapters.PlacementType `json:"placementtype"`
+	PlacementType           adapters.PlacementType `json:"placementtype"`
+	AllowsCustomCloseButton bool                   `json:"allowscustomclosebutton"`
 }
 
 // CrossInstallAdapter ...
@@ -126,7 +127,8 @@ func (adapter *CrossInstallAdapter) MakeRequests(request *openrtb.BidRequest, _ 
 				bannerCopy := *thisImp.Banner
 
 				bannerExt := crossinstallBannerExt{
-					PlacementType: placementType,
+					PlacementType:           placementType,
+					AllowsCustomCloseButton: false,
 				}
 				bannerCopy.Ext, err = json.Marshal(&bannerExt)
 				if err != nil {

--- a/adapters/liftoff/liftoff.go
+++ b/adapters/liftoff/liftoff.go
@@ -61,7 +61,8 @@ type liftoffVideoExt struct {
 }
 
 type liftoffBannerExt struct {
-	PlacementType string `json:"placementtype"`
+	PlacementType           string `json:"placementtype"`
+	AllowsCustomCloseButton bool   `json:"allowscustomclosebutton"`
 }
 
 type liftoffImpExt struct {
@@ -182,7 +183,8 @@ func (a *LiftoffAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adap
 			if liftoffExt.MRAIDSupported {
 				bannerCopy := *thisImp.Banner
 				bannerExt := liftoffBannerExt{
-					PlacementType: string(placementType),
+					PlacementType:           string(placementType),
+					AllowsCustomCloseButton: false,
 				}
 				bannerCopy.Ext, err = json.Marshal(&bannerExt)
 				if err != nil {

--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -32,7 +32,8 @@ type molocoVideoExt struct {
 }
 
 type molocoBannerExt struct {
-	PlacementType adapters.PlacementType `json:"placementtype"`
+	PlacementType           adapters.PlacementType `json:"placementtype"`
+	AllowsCustomCloseButton bool                   `json:"allowscustomclosebutton"`
 }
 
 type molocoImpExt struct {
@@ -152,7 +153,8 @@ func (adapter *MolocoAdapter) MakeRequests(request *openrtb.BidRequest, _ *adapt
 				bannerCopy := *thisImp.Banner
 
 				bannerExt := molocoBannerExt{
-					PlacementType: placementType,
+					PlacementType:           placementType,
+					AllowsCustomCloseButton: false,
 				}
 				bannerCopy.Ext, err = json.Marshal(&bannerExt)
 				if err != nil {

--- a/adapters/taurusx/taurusx.go
+++ b/adapters/taurusx/taurusx.go
@@ -32,7 +32,8 @@ type taurusxVideoExt struct {
 }
 
 type taurusxBannerExt struct {
-	Rewarded int `json:"rewarded"`
+	Rewarded                int  `json:"rewarded"`
+	AllowsCustomCloseButton bool `json:"allowscustomclosebutton"`
 }
 
 type taurusxImpExt struct {
@@ -136,7 +137,8 @@ func (adapter *TaurusXAdapter) MakeRequests(request *openrtb.BidRequest, _ *adap
 				bannerCopy := *thisImp.Banner
 
 				bannerExt := taurusxBannerExt{
-					Rewarded: taurusxExt.Reward,
+					Rewarded:                taurusxExt.Reward,
+					AllowsCustomCloseButton: false,
 				}
 				bannerCopy.Ext, err = json.Marshal(&bannerExt)
 				if err != nil {

--- a/adapters/unicorn/unicorn.go
+++ b/adapters/unicorn/unicorn.go
@@ -31,7 +31,8 @@ type unicornImpExt struct {
 }
 
 type unicornBannerExt struct {
-	Reward int `json:"reward"`
+	Reward                  int  `json:"reward"`
+	AllowsCustomCloseButton bool `json:"allowscustomclosebutton"`
 }
 
 // UnicornAdapter ...
@@ -119,7 +120,8 @@ func (adapter *UnicornAdapter) MakeRequests(request *openrtb.BidRequest, _ *adap
 				bannerCopy := *thisImp.Banner
 
 				bannerExt := unicornBannerExt{
-					Reward: unicornExt.Reward,
+					Reward:                  unicornExt.Reward,
+					AllowsCustomCloseButton: false,
 				}
 				bannerCopy.Ext, err = json.Marshal(&bannerExt)
 				if err != nil {


### PR DESCRIPTION
## JIRA
[TPE-137](https://tapjoy.atlassian.net/browse/TPE-137)

## Description
This PR is to add custom close button disable support for our DSP partners, especially for Liftoff.

We're testing MRAID with Liftoff, but creative team warned us that MRAID ads come with custom close button, so when they put Tapjoy's close button too, it looks bad.

We investigated the issue and asked questions to Liftoff, and learned that they're respecting `allowcustomclosebutton` field in banner->ext. Therefore, with this PR, we'll always be passing `false` to disable custom close button.

Note that this feature is implemented for all currently integrated DSPs but Rubicon, because Rubicon has a custom XAPI that doesn't support this flag. MRAID for Rubicon is not in out plans anyway.

This feature will be default for the following DSP integrations.