### PR TITLE
[NGS-260] Support for multiple SKAN ID Lists - 2

### DIFF
--- a/adapters/taurusx/taurusx.go
+++ b/adapters/taurusx/taurusx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/cache/skanidlist"
 	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbs"
@@ -154,7 +155,10 @@ func (adapter *TaurusXAdapter) MakeRequests(request *openrtb.BidRequest, _ *adap
 
 		impExt := taurusxImpExt{}
 		if taurusxExt.SKADNSupported {
-			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, taurusxExtSKADNetIDs)
+			skanIDList := skanidlist.Get(openrtb_ext.BidderTaurusX)
+
+			skadn := adapters.FilterPrebidSKADNExt(bidderExt.Prebid, skanIDList)
+
 			// only add if present
 			if len(skadn.SKADNetIDs) > 0 {
 				impExt.SKADN = &skadn

--- a/cache/skanidlist/cache.go
+++ b/cache/skanidlist/cache.go
@@ -1,0 +1,180 @@
+package skanidlist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/prebid/prebid-server/cache/skanidlist/model"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+type cache struct {
+	url        string
+	successTTL time.Duration
+	missTTL    time.Duration
+	bidder     openrtb_ext.BidderName
+
+	ids map[string]bool
+
+	mu              *sync.RWMutex
+	expiration      int64
+	updateRequested bool
+}
+
+func newCache(url string, bidder openrtb_ext.BidderName) *cache {
+	return &cache{
+		url:        url,
+		successTTL: time.Duration(1 * time.Hour),
+		missTTL:    time.Duration(5 * time.Minute),
+		bidder:     bidder,
+
+		ids: map[string]bool{},
+
+		mu:              new(sync.RWMutex),
+		expiration:      time.Now().UnixNano(),
+		updateRequested: false,
+	}
+}
+
+func (c *cache) get() map[string]bool {
+	if len(c.url) < 1 {
+		// bidder does not support multiple SKAN ID List
+		return map[string]bool{}
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.ids
+}
+
+func (c *cache) update(ctx context.Context, httpClient *http.Client) {
+	chResp := make(chan *response, 1)
+
+	c.mu.Lock()
+	if time.Now().UnixNano() > c.expiration && !c.updateRequested {
+		c.updateRequested = true
+
+		c.mu.Unlock()
+
+		// get newrelic transaction from context
+		txn := newrelic.FromContext(ctx)
+
+		fetchFromServer := func(ctx context.Context, txn *newrelic.Transaction) {
+			ctx = newrelic.NewContext(ctx, txn)
+			chResp <- c.fetchFromServer(ctx, httpClient)
+		}
+		go fetchFromServer(ctx, txn.NewGoroutine())
+
+	} else {
+		c.mu.Unlock()
+
+		chResp <- &response{
+			skanIDList: model.SKANIDList{},
+			updated:    false,
+			err:        nil,
+		}
+	}
+
+	resp := <-chResp
+
+	if resp.err != nil {
+		// http call returned error, list could not fetched, report NR error
+		if txn := newrelic.FromContext(ctx); txn != nil {
+			txn.NoticeError(resp.err)
+		}
+
+		// update expiration and updateRequested fields to check back in miss TTL time
+		c.updateMiss()
+
+		return
+	}
+
+	if !resp.updated {
+		// update is not required so do not change anything
+		return
+	}
+
+	c.updateSuccess(resp.skanIDList)
+}
+
+func (c *cache) fetchFromServer(ctx context.Context, httpClient *http.Client) *response {
+	req, err := http.NewRequest("GET", c.url, nil)
+	if err != nil {
+		return &response{
+			skanIDList: model.SKANIDList{},
+			updated:    false,
+			err:        errors.New(fmt.Sprintf("error making request for bidder's servers for: %s - %v", c.url, err)),
+		}
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := ctxhttp.Do(ctx, httpClient, req)
+	if err != nil {
+		return &response{
+			skanIDList: model.SKANIDList{},
+			updated:    false,
+			err:        errors.New(fmt.Sprintf("error fetching skanidlist from bidder's servers for: %s - %v", c.url, err)),
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &response{
+			skanIDList: model.SKANIDList{},
+			updated:    false,
+			err:        errors.New(fmt.Sprintf("error statuscode (%d) received from bidder's servers for: %s - %v", resp.StatusCode, c.url, err)),
+		}
+	}
+
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &response{
+			skanIDList: model.SKANIDList{},
+			updated:    true,
+			err:        errors.New(fmt.Sprintf("error reading skanidlist response body for: %s - %v", c.url, err)),
+		}
+	}
+
+	var skanIDList model.SKANIDList
+	err = json.Unmarshal(data, &skanIDList)
+	if err != nil {
+		return &response{
+			skanIDList: model.SKANIDList{},
+			updated:    true,
+			err:        errors.New(fmt.Sprintf("error unmarshaling response to skanidlist for: %s - %v", c.url, err)),
+		}
+	}
+
+	return &response{
+		skanIDList: skanIDList,
+		updated:    true,
+		err:        nil,
+	}
+}
+
+func (c *cache) updateSuccess(skanIDList model.SKANIDList) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.ids = extract(skanIDList)
+	c.expiration = time.Now().Add(c.successTTL).UnixNano()
+	c.updateRequested = false
+}
+
+func (c *cache) updateMiss() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.expiration = time.Now().Add(c.missTTL).UnixNano()
+	c.updateRequested = false
+}

--- a/cache/skanidlist/client.go
+++ b/cache/skanidlist/client.go
@@ -1,0 +1,38 @@
+package skanidlist
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+type client map[openrtb_ext.BidderName]*cache
+
+// Empty skanIDListClient
+var skanIDListClient client = client{}
+
+func cacheClient(bidder openrtb_ext.BidderName) *cache {
+	if _, ok := skanIDListClient[bidder]; !ok {
+		// Initialize bidder caches at first call
+		switch bidder {
+		case openrtb_ext.BidderTaurusX:
+			skanIDListClient[bidder] = newCache("https://www.taurusx.com/skadnetworkids.json", bidder)
+		}
+	}
+
+	return skanIDListClient[bidder]
+}
+
+func Update(ctx context.Context, httpClient *http.Client, bidder openrtb_ext.BidderName) {
+	if c := cacheClient(bidder); c != nil {
+		c.update(ctx, httpClient)
+	}
+}
+
+func Get(bidder openrtb_ext.BidderName) map[string]bool {
+	if c := cacheClient(bidder); c != nil {
+		return c.get()
+	}
+	return map[string]bool{}
+}

--- a/cache/skanidlist/model/skanidlist.go
+++ b/cache/skanidlist/model/skanidlist.go
@@ -1,0 +1,17 @@
+package model
+
+// SKANIDList format: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/skadnetwork.md#iabtl-managed-skadnetwork-id-list
+type SKANIDList struct {
+	CompanyName    string           `json:"company_name"`
+	CompanyAddress string           `json:"company_address"`
+	CompanyDomain  string           `json:"company_domain"`
+	SKAdNetworkIDs []SKAdNetworkIDs `json:"skadnetwork_ids"`
+}
+
+type SKAdNetworkIDs struct {
+	ID            int    `json:"id"`
+	EntityName    string `json:"entity_name"`
+	EntityDomain  string `json:"entity_domain"`
+	SKAdNetworkID string `json:"skadnetwork_id"`
+	CreationDate  string `json:"creation_date"`
+}

--- a/cache/skanidlist/response.go
+++ b/cache/skanidlist/response.go
@@ -1,0 +1,9 @@
+package skanidlist
+
+import "github.com/prebid/prebid-server/cache/skanidlist/model"
+
+type response struct {
+	skanIDList model.SKANIDList
+	updated    bool
+	err        error
+}

--- a/cache/skanidlist/util.go
+++ b/cache/skanidlist/util.go
@@ -1,0 +1,13 @@
+package skanidlist
+
+import "github.com/prebid/prebid-server/cache/skanidlist/model"
+
+func extract(skanIDList model.SKANIDList) map[string]bool {
+	skanIDs := map[string]bool{}
+
+	for _, skanID := range skanIDList.SKAdNetworkIDs {
+		skanIDs[skanID.SKAdNetworkID] = true
+	}
+
+	return skanIDs
+}

--- a/exchange/bidder_validate_bids.go
+++ b/exchange/bidder_validate_bids.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/mxmCherry/openrtb"
@@ -34,6 +35,10 @@ func (v *validatedBidder) requestBid(ctx context.Context, request *openrtb.BidRe
 		errs = append(errs, validationErrors...)
 	}
 	return seatBid, errs
+}
+
+func (v *validatedBidder) client() *http.Client {
+	return v.bidder.client()
 }
 
 // validateBids will run some validation checks on the returned bids and excise any invalid bids

--- a/exchange/bidder_validate_bids_test.go
+++ b/exchange/bidder_validate_bids_test.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/mxmCherry/openrtb"
@@ -259,4 +260,8 @@ type mockAdaptedBidder struct {
 
 func (b *mockAdaptedBidder) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions, reqInfo *adapters.ExtraRequestInfo) (*pbsOrtbSeatBid, []error) {
 	return b.bidResponse, b.errorResponse
+}
+
+func (m *mockAdaptedBidder) client() *http.Client {
+	return http.DefaultClient
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/cache/skanidlist"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/currencies"
 	"github.com/prebid/prebid-server/errortypes"
@@ -351,6 +352,8 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 		coreBidder := resolveBidder(string(bidderName), aliases)
 		bidderRunner := e.recoverSafely(cleanRequests, func(ctx context.Context, txn *newrelic.Transaction, aName openrtb_ext.BidderName, coreBidder openrtb_ext.BidderName, request *openrtb.BidRequest, bidlabels *pbsmetrics.AdapterLabels, conversions currencies.Conversions) {
 			ctx = newrelic.NewContext(ctx, txn)
+
+			skanidlist.Update(ctx, e.adapterMap[coreBidder].client(), coreBidder)
 
 			// Passing in aName so a doesn't change out from under the go routine
 			if bidlabels.Adapter == "" {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2455,6 +2455,10 @@ func (b *validatingBidder) requestBid(ctx context.Context, request *openrtb.BidR
 	return
 }
 
+func (b *validatingBidder) client() *http.Client {
+	return http.DefaultClient
+}
+
 func diffOrtbRequests(t *testing.T, description string, expected *openrtb.BidRequest, actual *openrtb.BidRequest) {
 	t.Helper()
 	actualJSON, err := json.Marshal(actual)
@@ -2585,4 +2589,8 @@ type panicingAdapter struct{}
 
 func (panicingAdapter) requestBid(ctx context.Context, request *openrtb.BidRequest, name openrtb_ext.BidderName, bidAdjustment float64, conversions currencies.Conversions, reqInfo *adapters.ExtraRequestInfo) (posb *pbsOrtbSeatBid, errs []error) {
 	panic("Panic! Panic! The world is ending!")
+}
+
+func (p panicingAdapter) client() *http.Client {
+	return http.DefaultClient
 }

--- a/exchange/legacy.go
+++ b/exchange/legacy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 
 	"github.com/buger/jsonparser"
 	"github.com/mxmCherry/openrtb"
@@ -135,6 +136,10 @@ func (bidder *adaptedAdapter) toLegacyRequest(req *openrtb.BidRequest) (*pbs.PBS
 		// Start is excluded because no legacy adapters read from it
 		Regs: req.Regs,
 	}, nil
+}
+
+func (bidder *adaptedAdapter) client() *http.Client {
+	return http.DefaultClient
 }
 
 func toAccountId(req *openrtb.BidRequest) (string, error) {


### PR DESCRIPTION
## JIRA 
https://tapjoy.atlassian.net/browse/NGS-260

## Description
This PR is to add support for Multiple SKAN ID Lists for SSPs.

Currently, each Bidder has a single SKAN ID. But some Bidders (SSPs like Rubicon, PubMatic, TaurusX etc.) needs to provide a list of SKAN IDs and Tapjoy needs to use that list when making their individual Bidder requests. Bidders who support this feature are hosting the list as json or xml on their servers and provides URL for us to fetch from. Details of it can be found here: https://docs.google.com/document/d/18DESlWha9OD_7E3iSpfz9r7qdb52LHNhjF_GC6Sz20A/edit?usp=sharing

This implementation has monitoring around the fetching calls and reports to NR if fetching fails. Flow is as follows:
- Before making individual requests for bidders, call client's Update function to fetch files from Bidder's servers (This update request is per request but if the data hasn't been expired (TTL is 1 hour), then it uses the data in the cache)
- If a request is SKAN eligible, call client's Get function to get the list in the cache.

Note: To be able to support monitoring, I needed to extend `adaptedBidder` interface by adding `client()` method. I'm using bidder's client (shared generalHTTPClient) to make SKAN ID List HTTP calls.

## How to test
- Spin up local k8s (add NR key to manifest.yaml to monitor from NR dashboard)
Success flow:
- Send a SKAN eligible request from ad_service or MBS
- Print the outgoing request
Fail flow:
- Update SKAN ID List URLs so that it fails, check NR for error reporting
