### PR TITLE
[NGS-260] SKAN ID List Client Sync

### DIFF
--- a/cache/skanidlist/cache.go
+++ b/cache/skanidlist/cache.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/prebid/prebid-server/cache/skanidlist/cfg"
 	"github.com/prebid/prebid-server/cache/skanidlist/model"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"golang.org/x/net/context/ctxhttp"
@@ -29,12 +30,12 @@ type cache struct {
 	updateRequested bool
 }
 
-func newCache(url string, bidder openrtb_ext.BidderName) *cache {
-	return &cache{
-		url:        url,
+func newCache(cfg cfg.Cache) *cache {
+	c := cache{
+		url:        cfg.Url,
 		successTTL: time.Duration(1 * time.Hour),
 		missTTL:    time.Duration(5 * time.Minute),
-		bidder:     bidder,
+		bidder:     cfg.Bidder,
 
 		ids: map[string]bool{},
 
@@ -42,6 +43,14 @@ func newCache(url string, bidder openrtb_ext.BidderName) *cache {
 		expiration:      time.Now().UnixNano(),
 		updateRequested: false,
 	}
+
+	if cfg.BidderSKANID != "" {
+		c.ids = map[string]bool{
+			cfg.BidderSKANID: true,
+		}
+	}
+
+	return &c
 }
 
 func (c *cache) get() map[string]bool {

--- a/cache/skanidlist/cfg/cfg.go
+++ b/cache/skanidlist/cfg/cfg.go
@@ -1,0 +1,9 @@
+package cfg
+
+import "github.com/prebid/prebid-server/openrtb_ext"
+
+type Cache struct {
+	Url          string
+	Bidder       openrtb_ext.BidderName
+	BidderSKANID string
+}

--- a/cache/skanidlist/cfg/pubmatic.go
+++ b/cache/skanidlist/cfg/pubmatic.go
@@ -1,0 +1,9 @@
+package cfg
+
+import "github.com/prebid/prebid-server/openrtb_ext"
+
+var Pubmatic Cache = Cache{
+	Url:          "https://pubmatic.com/skadnetworkids.json",
+	Bidder:       openrtb_ext.BidderPubmatic,
+	BidderSKANID: "k674qkevps.skadnetwork",
+}

--- a/cache/skanidlist/cfg/taurusx.go
+++ b/cache/skanidlist/cfg/taurusx.go
@@ -1,0 +1,9 @@
+package cfg
+
+import "github.com/prebid/prebid-server/openrtb_ext"
+
+var TaurusX Cache = Cache{
+	Url:          "https://www.taurusx.com/skadnetworkids.json",
+	Bidder:       openrtb_ext.BidderTaurusX,
+	BidderSKANID: "22mmun2rn5.skadnetwork",
+}

--- a/cache/skanidlist/client.go
+++ b/cache/skanidlist/client.go
@@ -2,37 +2,66 @@ package skanidlist
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"sync"
 
+	"github.com/prebid/prebid-server/cache/skanidlist/cfg"
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-type client map[openrtb_ext.BidderName]*cache
+type client struct {
+	caches map[openrtb_ext.BidderName]*cache
+	mu     *sync.Mutex
+}
 
 // Empty skanIDListClient
-var skanIDListClient client = client{}
+var skanIDListClient client = client{
+	caches: map[openrtb_ext.BidderName]*cache{},
+	mu:     new(sync.Mutex),
+}
 
-func cacheClient(bidder openrtb_ext.BidderName) *cache {
-	if _, ok := skanIDListClient[bidder]; !ok {
-		// Initialize bidder caches at first call
-		switch bidder {
-		case openrtb_ext.BidderTaurusX:
-			skanIDListClient[bidder] = newCache("https://www.taurusx.com/skadnetworkids.json", bidder)
+func (c client) makeCache(cfg cfg.Cache) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.caches[cfg.Bidder] == nil {
+		c.caches[cfg.Bidder] = newCache(cfg)
+	}
+}
+
+func cacheClient(bidder openrtb_ext.BidderName) (*cache, error) {
+	// Initialize bidder caches at first call
+	switch bidder {
+	case openrtb_ext.BidderTaurusX:
+		if skanIDListClient.caches[bidder] == nil {
+			skanIDListClient.makeCache(cfg.TaurusX)
 		}
+		return skanIDListClient.caches[bidder], nil
+
+		/*
+			case openrtb_ext.BidderPubmatic:
+				if skanIDListClient.caches[bidder] == nil {
+					skanIDListClient.makeCache(cfg.Pubmatic)
+				}
+				return skanIDListClient.caches[bidder], nil
+		*/
 	}
 
-	return skanIDListClient[bidder]
+	return nil, errors.New(fmt.Sprintf("bidder (%s) does not support SKAN ID List", bidder))
 }
 
 func Update(ctx context.Context, httpClient *http.Client, bidder openrtb_ext.BidderName) {
-	if c := cacheClient(bidder); c != nil {
+	if c, err := cacheClient(bidder); err == nil {
 		c.update(ctx, httpClient)
 	}
 }
 
 func Get(bidder openrtb_ext.BidderName) map[string]bool {
-	if c := cacheClient(bidder); c != nil {
+	if c, err := cacheClient(bidder); err == nil {
 		return c.get()
 	}
+
 	return map[string]bool{}
 }


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-260

## Description
This PR is a fix for SKAN ID list client synchronization upon testing requirements of PubMatic.

First of all, thanks @shahbaztariq for detecting this issue and working on a fix, appreciate it!

Summary of the issue is, we wanted to test PubMatic req/resps with SKADN. Because we use a singleton for SKAN cache clients, first call would fetch the list from server in a goroutine so first Get call gets an empty list until the HTTP call response after ~300ms. However we needed consistent testing, so we decided to initialize Bidder SKAN ID List caches with Bidder's single SKAN ID. When we wanted to do it, we saw that it created a race condition because the `getting the client` isn't thread safe even though every `write to cache` and `read from cache` is thread safe.

As a result, we decided to add a mutex lock to cache initializations.

NOTE: There is no issue with the current production code, so nothing to worry about.

## How to test
same as https://github.com/Tapjoy/tpe_prebid_service/pull/48