### PR TITLE
[NGS-329] Versions for SKAN 2.2

### DIFF
--- a/adapters/openrtb_util.go
+++ b/adapters/openrtb_util.go
@@ -193,6 +193,7 @@ func FilterPrebidSKADNExt(prebidExt *openrtb_ext.ExtImpPrebid, filterMap map[str
 
 	return openrtb_ext.SKADN{
 		Version:    prebidExt.SKADN.Version,
+		Versions:   prebidExt.SKADN.Versions,
 		SourceApp:  prebidExt.SKADN.SourceApp,
 		SKADNetIDs: filterArrayWithMap(prebidExt.SKADN.SKADNetIDs, filterMap),
 	}

--- a/openrtb_ext/imp.go
+++ b/openrtb_ext/imp.go
@@ -40,6 +40,7 @@ type ExtStoredRequest struct {
 // SKADN ..
 type SKADN struct {
 	Version    string   `json:"version,omitempty"`
+	Versions   []string `json:"versions,omitempty"`
 	SourceApp  string   `json:"sourceapp,omitempty"`
 	SKADNetIDs []string `json:"skadnetids,omitempty"`
 }

--- a/testdata/responses/liftoff/fill_high_bid_mraid_skadn_2_2.json
+++ b/testdata/responses/liftoff/fill_high_bid_mraid_skadn_2_2.json
@@ -34,8 +34,8 @@
             "skadn": {
               "version": "2.2",
               "network": "7ug5zh24hu.skadnetwork",
-              "campaign": "some_liftoff_campaign_id",
-              "itunesitem": "com.should.match",
+              "campaign": "123",
+              "itunesitem": "14522332",
               "sourceapp": "691244553",
               "fidelities": [
                 {

--- a/testdata/responses/liftoff/fill_high_bid_skadn_2_2.json
+++ b/testdata/responses/liftoff/fill_high_bid_skadn_2_2.json
@@ -34,8 +34,8 @@
             "skadn": {
               "version": "2.2",
               "network": "7ug5zh24hu.skadnetwork",
-              "campaign": "some_liftoff_campaign_id",
-              "itunesitem": "com.should.match",
+              "campaign": "123",
+              "itunesitem": "14522332",
               "sourceapp": "691244553",
               "fidelities": [
                 {


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-329

## Description
This PR is to add Versions array to SKADN data to support SKAN version 2.2. Also it updates the values in SKAN version 2.2 test files to have correct types.

## How this was tested
Fired an Easy App request with SDK 12.8.1 and device 14.4. Printed DSP requests in tpe_prebid_service pod. Confirmed we have Versions in the request for DSPs whose SKAN IDs in the info.plist.