### PR TITLE
[NGS-477] DV360 publisher.id overwrite

### DIFF
--- a/adapters/dv360/dv360.go
+++ b/adapters/dv360/dv360.go
@@ -213,6 +213,28 @@ func (adapter *DV360Adapter) MakeRequests(request *openrtb.BidRequest, requestIn
 		// to the request object
 		request.Imp = []openrtb.Imp{impCopy}
 
+		// overwrite publisher id with Tapjoy's apps-ads.txt id
+		var requestAppCopy openrtb.App
+		var requestAppPublisherCopy openrtb.Publisher
+
+		if request.App != nil {
+			requestAppCopy = *request.App
+		} else {
+			requestAppCopy = openrtb.App{}
+		}
+
+		if requestAppCopy.Publisher != nil {
+			requestAppPublisherCopy = *requestAppCopy.Publisher
+		} else {
+			requestAppPublisherCopy = openrtb.Publisher{}
+		}
+
+		requestAppPublisherCopy.ID = "1011b04a93164a6db3a0158461c82433"
+
+		requestAppCopy.Publisher = &requestAppPublisherCopy
+
+		request.App = &requestAppCopy
+
 		// json marshal the request
 		body, err := json.Marshal(request)
 		if err != nil {

--- a/adapters/dv360/dv360test/exemplary/app_banner.json
+++ b/adapters/dv360/dv360test/exemplary/app_banner.json
@@ -47,7 +47,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/app_banner_instl.json
+++ b/adapters/dv360/dv360test/exemplary/app_banner_instl.json
@@ -48,7 +48,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/app_video_instl.json
+++ b/adapters/dv360/dv360test/exemplary/app_video_instl.json
@@ -54,7 +54,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/app_video_rewarded.json
+++ b/adapters/dv360/dv360test/exemplary/app_video_rewarded.json
@@ -56,7 +56,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/ip_truncated.json
+++ b/adapters/dv360/dv360test/exemplary/ip_truncated.json
@@ -51,6 +51,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/merged_device_ext.json
+++ b/adapters/dv360/dv360test/exemplary/merged_device_ext.json
@@ -57,6 +57,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/skan_app_banner.json
+++ b/adapters/dv360/dv360test/exemplary/skan_app_banner.json
@@ -56,7 +56,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/skan_app_banner_instl.json
+++ b/adapters/dv360/dv360test/exemplary/skan_app_banner_instl.json
@@ -57,7 +57,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/exemplary/skan_video_interstitial.json
+++ b/adapters/dv360/dv360test/exemplary/skan_video_interstitial.json
@@ -60,6 +60,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/skan_video_rewarded.json
+++ b/adapters/dv360/dv360test/exemplary/skan_video_rewarded.json
@@ -60,6 +60,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/truncated_ipv4.json
+++ b/adapters/dv360/dv360test/exemplary/truncated_ipv4.json
@@ -55,6 +55,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/truncated_ipv6.json
+++ b/adapters/dv360/dv360test/exemplary/truncated_ipv6.json
@@ -55,6 +55,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/video_interstitial.json
+++ b/adapters/dv360/dv360test/exemplary/video_interstitial.json
@@ -51,6 +51,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/exemplary/video_rewarded.json
+++ b/adapters/dv360/dv360test/exemplary/video_rewarded.json
@@ -52,6 +52,11 @@
         "uri": "https://bid.g.doubleclick.net/xbbe/bid/tapjoy",
         "body": {
           "id": "test-request-id",
+          "app": {
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
+          },
           "imp": [
             {
               "ext": {

--- a/adapters/dv360/dv360test/supplemental/response_code_204.json
+++ b/adapters/dv360/dv360test/supplemental/response_code_204.json
@@ -47,7 +47,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",

--- a/adapters/dv360/dv360test/supplemental/response_code_400.json
+++ b/adapters/dv360/dv360test/supplemental/response_code_400.json
@@ -47,7 +47,10 @@
         "body": {
           "id": "test-request-id",
           "app": {
-            "bundle": "com.prebid"
+            "bundle": "com.prebid",
+            "publisher": {
+              "id": "1011b04a93164a6db3a0158461c82433"
+            }
           },
           "device": {
             "ifa": "87857b31-8942-4646-ae80-ab9c95bf3fab",


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-477

## Description
This PR is to overwrite req->app->publisher->id field with Tapjoy's id in apps-ads.txt id (`1011b04a93164a6db3a0158461c82433`). Currently we're using request's app's publisher's encrypted ID but Google is complaining about this as it's stated in the IAB contract (https://iabtechlab.com/wp-content/uploads/2019/03/IAB-OpenRTB-Ads.txt-Public-Spec-1.0.2.pdf)

We'll talk to the other Bidders and fix this globally if necessary. For now, it's Google DV360 only.

## How to Test
Tested locally in k8s that we're overwriting this field only for Google DV360 with the value specified.