### PR TITLE
[NGS-295] Enable video for Rubicon MRAID

### DIFF
--- a/static/bidder-info/rubiconmraid.yaml
+++ b/static/bidder-info/rubiconmraid.yaml
@@ -5,3 +5,4 @@ capabilities:
   app:
     mediaTypes:
       - banner
+      - video


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-295

## Description
This PR is to enable video for Rubicon MRAID in bidder info yaml file. Prebid request has Video and Banner objects in the same impression object. When Rubicon MRAID bidder doesn't support Video, in prebid response, there is an error that says this even though it calls the endpoint and gets the response. This is opens circuit breaker on MBS because if the prebid response has errors for specific bidder, it counts that response as circuit breaker fail. We need to enable it, we'll be removing when making the request anyway.