### PR TITLE
[NGS-606] HeaderBidding flag and MediatorID in all DSP requests

### DIFF
--- a/adapters/mintegral/mintegral.go
+++ b/adapters/mintegral/mintegral.go
@@ -218,41 +218,6 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 			continue
 		}
 
-		reqSourceExt := map[string]interface{}{}
-		reqSourceExt["mediator_id"] = mintegralExt.MediatorID
-		reqSourceExt["header_bidding"] = mintegralExt.HeaderBidding
-
-		if request.Source != nil {
-			reqSource := *request.Source
-
-			if reqSource.Ext != nil {
-				if err = json.Unmarshal(reqSource.Ext, &reqSourceExt); err != nil {
-					errs = append(errs, &errortypes.BadInput{
-						Message: err.Error(),
-					})
-					continue
-				}
-			}
-
-			reqSource.Ext, err = json.Marshal(&reqSourceExt)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-
-			request.Source = &reqSource
-		} else {
-			reqSource := openrtb.Source{}
-
-			reqSource.Ext, err = json.Marshal(&reqSourceExt)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-
-			request.Source = &reqSource
-		}
-
 		request.Imp = []openrtb.Imp{thisImp}
 		request.Cur = nil
 		request.Ext = nil

--- a/adapters/mintegral/mintegraltest/exemplary/endpoint_empty.json
+++ b/adapters/mintegral/mintegraltest/exemplary/endpoint_empty.json
@@ -39,9 +39,7 @@
               "skipdelay": 5,
               "width": 320,
               "height": 480
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -94,13 +92,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/endpoint_hk.json
+++ b/adapters/mintegral/mintegraltest/exemplary/endpoint_hk.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 320,
               "height": 480
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/endpoint_not_supported.json
+++ b/adapters/mintegral/mintegraltest/exemplary/endpoint_not_supported.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 320,
               "height": 480
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/endpoint_vg.json
+++ b/adapters/mintegral/mintegraltest/exemplary/endpoint_vg.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 320,
               "height": 480
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/orientation_horizontal.json
+++ b/adapters/mintegral/mintegraltest/exemplary/orientation_horizontal.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 480,
               "height": 320
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/orientation_vertical.json
+++ b/adapters/mintegral/mintegraltest/exemplary/orientation_vertical.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 320,
               "height": 480
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/video_interstitial.json
+++ b/adapters/mintegral/mintegraltest/exemplary/video_interstitial.json
@@ -40,9 +40,7 @@
               "skipdelay": 5,
               "width": 480,
               "height": 320
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 0
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/video_rewarded.json
+++ b/adapters/mintegral/mintegraltest/exemplary/video_rewarded.json
@@ -40,9 +40,7 @@
               "skipdelay": 0,
               "width": 480,
               "height": 320
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 1
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/video_rewarded_header_bidding_programmatic.json
+++ b/adapters/mintegral/mintegraltest/exemplary/video_rewarded_header_bidding_programmatic.json
@@ -40,9 +40,7 @@
               "skipdelay": 0,
               "width": 480,
               "height": 320
-            },
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 1
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/mintegral/mintegraltest/exemplary/video_rewarded_header_bidding_waterfall.json
+++ b/adapters/mintegral/mintegraltest/exemplary/video_rewarded_header_bidding_waterfall.json
@@ -40,9 +40,7 @@
               "skipdelay": 0,
               "width": 480,
               "height": 320
-            },
-            "header_bidding": 0,
-            "mediator_id": "test_mediator_id"
+            }
           }
         }
       }
@@ -95,13 +93,7 @@
                 "rewarded": 1
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 0,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prebid/prebid-server/config"
 	"net/http"
+
+	"github.com/prebid/prebid-server/config"
 
 	openrtb "github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
@@ -193,41 +194,6 @@ func (adapter *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.Ex
 		if err != nil {
 			errs = append(errs, err)
 			continue
-		}
-
-		reqSourceExt := map[string]interface{}{}
-		reqSourceExt["mediator_id"] = molocoExt.MediatorID
-		reqSourceExt["header_bidding"] = molocoExt.HeaderBidding
-
-		if request.Source != nil {
-			reqSource := *request.Source
-
-			if reqSource.Ext != nil {
-				if err = json.Unmarshal(reqSource.Ext, &reqSourceExt); err != nil {
-					errs = append(errs, &errortypes.BadInput{
-						Message: err.Error(),
-					})
-					continue
-				}
-			}
-
-			reqSource.Ext, err = json.Marshal(&reqSourceExt)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-
-			request.Source = &reqSource
-		} else {
-			reqSource := openrtb.Source{}
-
-			reqSource.Ext, err = json.Marshal(&reqSourceExt)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-
-			request.Source = &reqSource
 		}
 
 		// reinit the values in the request object

--- a/adapters/moloco/molocotest/exemplary/endpoint_apac.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_apac.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "apac",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/endpoint_empty.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_empty.json
@@ -34,9 +34,7 @@
         },
         "ext": {
           "bidder": {
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -84,13 +82,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/endpoint_eu.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_eu.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "eu",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/endpoint_not_supported.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_not_supported.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "not_supported",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/endpoint_us_east.json
+++ b/adapters/moloco/molocotest/exemplary/endpoint_us_east.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/video_interstitial.json
+++ b/adapters/moloco/molocotest/exemplary/video_interstitial.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "placementtype": "interstitial",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "interstitial"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/video_rewarded.json
+++ b/adapters/moloco/molocotest/exemplary/video_rewarded.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -95,8 +93,6 @@
           "source": {
             "fd": 5,
             "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id",
               "test": "yolo!"
             }
           }

--- a/adapters/moloco/molocotest/exemplary/video_rewarded_header_bidding_programmatic.json
+++ b/adapters/moloco/molocotest/exemplary/video_rewarded_header_bidding_programmatic.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "placementtype": "rewarded",
-            "header_bidding": 1,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 1,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/adapters/moloco/molocotest/exemplary/video_rewarded_header_bidding_waterfall.json
+++ b/adapters/moloco/molocotest/exemplary/video_rewarded_header_bidding_waterfall.json
@@ -35,9 +35,7 @@
         "ext": {
           "bidder": {
             "region": "us_east",
-            "placementtype": "rewarded",
-            "header_bidding": 0,
-            "mediator_id": "test_mediator_id"
+            "placementtype": "rewarded"
           }
         }
       }
@@ -85,13 +83,7 @@
                 }
               }
             }
-          ],
-          "source": {
-            "ext": {
-              "header_bidding": 0,
-              "mediator_id": "test_mediator_id"
-            }
-          }
+          ]
         }
       },
       "mockResponse": {

--- a/openrtb_ext/imp_mintegral.go
+++ b/openrtb_ext/imp_mintegral.go
@@ -6,8 +6,6 @@ type ExtImpMintegral struct {
 	Region         string               `json:"region"`
 	SKADNSupported bool                 `json:"skadn_supported"`
 	MRAIDSupported bool                 `json:"mraid_supported"`
-	HeaderBidding  int                  `json:"header_bidding"`
-	MediatorID     string               `json:"mediator_id"`
 }
 
 // mintegralVideoParams defines the contract for bidrequest.imp[i].ext.mintegral.video

--- a/openrtb_ext/imp_moloco.go
+++ b/openrtb_ext/imp_moloco.go
@@ -6,6 +6,4 @@ type ExtImpMoloco struct {
 	Region         string `json:"region"`          // this field added to support multiple moloco endpoints
 	SKADNSupported bool   `json:"skadn_supported"` // enable skadn ext parameters
 	MRAIDSupported bool   `json:"mraid_supported"`
-	HeaderBidding  int    `json:"header_bidding"`
-	MediatorID     string `json:"mediator_id"`
 }


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-606

## Description
This PR is to add HeaderBidding flag and encrypted MediatorID to all DSPs' requests. Currently it's only Moloco and Mintegral. This is just a cleanup PR for this repo. As we're passing these values in source->ext (standard field), they're being handled automatically, no need to do any change here.

## Validation
HoneyComb

## Related PRs
- MBS: https://github.com/Tapjoy/mediation_bid_service/pull/1038
- AS: https://github.com/Tapjoy/ad_service/pull/954
- go-prebid: https://github.com/Tapjoy/go-prebid/pull/79
- tpe-prebid: https://github.com/Tapjoy/tpe_prebid_service/pull/100