### PR TITLE
add minimum floor of 5.0 for pubmatic requests

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -184,6 +184,11 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 					pbReq.Imp[i].Banner.W = openrtb2.Int64Ptr(int64(width))
 					pbReq.Imp[i].Banner.H = openrtb2.Int64Ptr(int64(height))
 
+					// for usa requests -- set bidfloor to a min of 5.0
+					if pbReq.Device != nil && pbReq.Device.Geo != nil && strings.ToLower(pbReq.Device.Geo.Country) == "usa" && pbReq.Imp[i].BidFloor < 5.0 {
+						pbReq.Imp[i].BidFloor = 5.0
+					}
+
 					if len(params.Keywords) != 0 {
 						kvstr := prepareImpressionExt(params.Keywords)
 						pbReq.Imp[i].Ext = json.RawMessage([]byte(kvstr))
@@ -362,6 +367,11 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 	// If all the requests are invalid, Call to adaptor is skipped
 	if len(request.Imp) == 0 {
 		return nil, errs
+	}
+
+	// for usa requests -- set bidfloor to a min of 5.0
+	if request.Device != nil && request.Device.Geo != nil && strings.ToLower(request.Device.Geo.Country) == "usa" && request.Imp[0].BidFloor < 5.0 {
+		request.Imp[0].BidFloor = 5.0
 	}
 
 	if wrapExt != "" {


### PR DESCRIPTION
Based on discussions with pubmatic, it was inferred that TJ bid floors are too low and hence their bidder considers our traffic of low value, then decides to no-bid or underbid. 

IS has provided some insight that we probably need to set static floors for brand dsp’s like pubmatic to get the bidder to recognize supply as valid.

As a test for all pubmatic US traffic, we would set the floor as 5$.  The logic will be as follows.

For all pubmatic US traffic, if the incoming bid-floor is below 5$, we set it to 5$

For all pubmatic US traffic, if the incoming bid-floor is above 5$, we will pass that as is.


JIRA: https://tapjoy.atlassian.net/browse/NGS-757