### PR TITLE
OPER-6066 Put app in production Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG ROOT_IMAGE
 FROM ${ROOT_IMAGE} as baseimage
 
 # Install OS-level language locales
-ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8 \
+    APP_ROOT=/go/src/github.com/tapjoy/tpe_prebid_service APP_USER=webuser APP_USER_UID=1001
+
 RUN apt-get update -q &&\
     apt-get install -yq --no-install-recommends locales locales-all &&\
     locale-gen $LANG && update-locale LANG=$LANG &&\
@@ -13,10 +15,20 @@ RUN apt-get update -q &&\
 
 # We install OS-level dependencies we need to work with the project
 RUN apt-get update -q &&\
-    apt-get install -y --no-install-recommends vim &&\
+    apt-get install -y --no-install-recommends  ca-certificates curl dnsutils iftop git gnupg2 htop iotop iproute2 jq less lsof rng-tools sysstat vim &&\
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-WORKDIR /go/src/github.com/tapjoy/tpe_prebid_service
+ENV CHAMBER_VERSION="v2.10.8"
+RUN curl -o /usr/local/bin/chamber "https://tj-ops.s3.amazonaws.com/k8s-production/chamber-${CHAMBER_VERSION}-linux-$(uname -m)" &&\
+    chmod +x /usr/local/bin/chamber &&\
+    chamber version
+
+RUN mkdir -p ${APP_ROOT} &&\
+    useradd -m -u ${APP_USER_UID} ${APP_USER} &&\
+    usermod -G staff -a ${APP_USER} &&\
+    chown -R ${APP_USER}:${APP_USER} ${APP_ROOT}
+
+WORKDIR ${APP_ROOT}
 
 ###################
 # Build-time prep #
@@ -32,6 +44,7 @@ ADD . .
 # Clean up
 RUN git clean -fxd &&\
     make artifact-prep &&\
+    chown -R ${APP_USER}:${APP_USER} ${APP_ROOT} &&\
     rm -rf .git /tmp/*
 
 ###################
@@ -39,9 +52,17 @@ RUN git clean -fxd &&\
 ###################
 
 FROM baseimage as artifact
-COPY --from=artifact-prep /go/src/github.com/tapjoy/tpe_prebid_service /project
+
+USER ${APP_USER}
+
+COPY --from=artifact-prep ${APP_ROOT} /project
 WORKDIR /project
 
+# Gut check
+RUN ./tpe_prebid_service --help
+
 # @see https://github.com/Tapjoy/tpe_prebid_service/blob/9d0e0c46bb90a4fb818305b06d55725817882697/config/config.go#L570-L571
-EXPOSE 8000 # Viper port
-EXPOSE 6060 # Admin port
+## Viper port
+EXPOSE 8000
+## Admin port
+EXPOSE 6060

--- a/deploy/build
+++ b/deploy/build
@@ -4,40 +4,4 @@
 
 set -eux
 
-GIT_TAG=$(git rev-parse --short HEAD)
-IMAGE_TAG=baseimage
-# PROJECT_NAME var will be passed in by the slug builder container
-IMAGE_NAME=localhost:5000/tapjoy/${PROJECT_NAME}
-PROJECT_HOME=/go/src/github.com/tapjoy/${PROJECT_NAME}
-
-# BEGIN FUNCTIONS
-
-function run_build() {
-  # Tag new build-container image w/ SHA if the Dockerfile has changed.
-  if [[ ! -z "$(git diff origin/master Dockerfile)" ]]; then
-    echo "Dockerfile updates detected. Updating application's base image."
-    ## Affix git tag to base image to be built, from which a container will be created,
-    ## in which the deployment artifact will be built.
-    IMAGE_TAG=${IMAGE_TAG}-${GIT_TAG}
-  fi
-
-  # Build the base image for build container. If the Dockerfile hasn't changed, the image will
-  # likely be in the Docker build cache already.
-  IMAGE_TAG=${IMAGE_TAG} make baseimage
-
-  # Run the deployment artifact preparation steps (prepare_for_deployment function in entrypoint)
-  ## - This Docker command will be run in the context of a `slugforge build` call by the Jenkins slug builder
-  ## - Setting BUNDLE_APP_CONFIG is required because the official Ruby image sets this variable, which breaks artifact builds
-  docker run --rm \
-    -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
-    -e PROJECT_NAME \
-    -e BUNDLE_APP_CONFIG=.bundle \
-    -v "$(pwd):${PROJECT_HOME:-/project}" \
-    -v ~/.ssh/:/root/.ssh/ \
-    "${IMAGE_NAME}:${IMAGE_TAG}" \
-    make artifact-prep
-}
-
-# END FUNCTIONS
-
-run_build
+make slug-builder

--- a/deploy/kubernetes/base/app.yaml
+++ b/deploy/kubernetes/base/app.yaml
@@ -20,8 +20,20 @@ kind: Deployment
 metadata:
   name: tpe-prebid-service
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: 0 # We must *always* be at/above HPA-determined capacity so we will roll out by *first* scaling up
   template:
     spec:
+      securityContext:
+        fsGroup: 65534
+        sysctls:
+        # https://v1-21.docs.kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
+          - name: "net.ipv4.ip_local_port_range"
+            value: "1024 65023"
+      serviceAccountName: tpe-prebid-service
       containers:
         - name: app
           image: app
@@ -48,16 +60,12 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
-              name: tpe-prebid-service-env
+                name: tpe-prebid-service-env
           resources:
           ports:
             - name: app
               containerPort: 8000
               protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: app
         - name: nginx
           image: nginx
           imagePullPolicy: Always

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
   - app.yaml
+
+configMapGenerator:
+  - name: tpe-prebid-service-env

--- a/deploy/kubernetes/components/tooling/production/entrypoint-aws.sh
+++ b/deploy/kubernetes/components/tooling/production/entrypoint-aws.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# This entrypoint is intended to setup the execution environment based on infrastructure-specific things that don't
+# make sense to hardcode, e.g. AWS region.
+
+################################################################################
+# ENVIRONMENT
+################################################################################
+
+set -eu
+
+################################################################################
+# FUNCTIONS
+################################################################################
+
+function get_aws_metadata_by_path() {
+  curl -s http://169.254.169.254/latest/meta-data/${1}
+}
+
+function nr_host() {
+  # e.g. `web-5678cb4f4b-zcml8`
+  echo ${MY_NODE_NAME} | awk -F. '{print $1}'
+}
+
+################################################################################
+# PIPELINES
+################################################################################
+
+# For cloud libraries/tooling
+export AWS_AVAILABILITY_ZONE=$(get_aws_metadata_by_path placement/availability-zone)
+export AWS_DEFAULT_REGION=$(echo ${AWS_AVAILABILITY_ZONE} | sed 's/.$//')
+
+# For the app
+export AVAILABILITY_ZONE=${AWS_AVAILABILITY_ZONE}
+export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="$(echo ${AWS_AVAILABILITY_ZONE}: $(nr_host))"
+
+# If the method of supplying args changes, the need for quotes may change.
+exec bash -l -c "$*"

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tpe-prebid-service
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::266171351246:role/tpe_prebid_service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tpe-prebid-service
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tapjoy-tooling
+          configMap:
+            name: tpe-prebid-service-tooling
+            defaultMode: 0755 # Make scripts executable
+      containers:
+        - name: app
+          command: ["/tapjoy/tooling/entrypoint-aws.sh"]
+          args:
+            # TODO Remove env var overrides once app runs exclusively in k8s or the env vars are no longer published
+            # PBS_ADAPTERS_TAPJOY_ENDPOINT setup is a gift for devs living in a future when optsoa runs in EKS
+            - chamber exec devops/aws/production/tpe_prebid_service-web_internal/env --
+              env PBS_ADAPTERS_TAPJOY_ENDPOINT=http://legacy-discovery:7286/bid
+              ./tpe_prebid_service
+          resources:
+            requests:
+              cpu: 500m # Total guess
+              memory: 150Mi # Total guess
+            limits:
+              cpu: 3000m # Total guess
+              memory: 2000Mi # Total guess
+          volumeMounts:
+            - name: tapjoy-tooling
+              mountPath: /tapjoy/tooling
+              readOnly: true
+          # Attempt to restart container if the app is truly unavailable for 1min
+          livenessProbe:
+            tcpSocket:
+              port: app
+            failureThreshold: 6
+            successThreshold: 1
+          # Introduce a delay to the shutdown sequence to wait for the
+          # pod to be taken out of Service backends.
+          ## https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - sleep 30
+          # Introduce a delay to the shutdown sequence to wait for the
+          # pod to be taken out of Service backends.
+          ## https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
+        - name: nginx
+          readinessProbe:
+            periodSeconds: 1
+            failureThreshold: 1
+            successThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - sleep 30 && /usr/sbin/nginx -s quit

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/hpa.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/hpa.yaml
@@ -1,0 +1,25 @@
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: tpe-prebid-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tpe-prebid-service
+ # DO NOT increase scaling thresholds & change Pod resource requests in the same deploy. HPA changes do not go through
+ # a canary-style burn-in period. Instead they are applied immediately, and take effect while the prior workload is
+ # still running. Changing pod resource requests while increasing scaling thresholds can severely constrain capacity.
+ #
+ # Decreasing thresholds or adding another metric while making resource changes is okay, as it can only result in
+ # *more* capacity. The HPA controller chooses the calculation that results in the most replicas.
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  minReplicas: 5
+  maxReplicas: 300

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -21,10 +21,13 @@ components:
 - ../../../components/tooling/production
 
 configMapGenerator:
-- name: tpe-prebid-service-env
-  behavior: merge
+- behavior: merge
+  name: tpe-prebid-service-env
 
 images:
+- name: app
+  newName: localhost:5000/tapjoy/tpe_prebid_service
+  newTag: d8a7c8f163ed34fbf2b02d52d95bda1fd1c5b0bd
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -web-internal
+
+commonLabels:
+  app.kubernetes.io/instance: web_internal
+  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: tpe_prebid_service
+  ops.tapjoy.net/billing-category: cogs
+  ops.tapjoy.net/environment: legacy-production-eks
+
+resources:
+- ../../../base/
+- hpa.yaml
+
+patchesStrategicMerge:
+- app-patch.yaml
+
+components:
+- ../../../components/tooling/production
+
+configMapGenerator:
+- name: tpe-prebid-service-env
+  behavior: merge
+
+images:
+- name: nginx
+  newName: localhost:5000/tapjoy/nginx
+  newTag: latest

--- a/deploy/kubernetes/overlays/localdev/web-internal/app-patch.yaml
+++ b/deploy/kubernetes/overlays/localdev/web-internal/app-patch.yaml
@@ -25,6 +25,8 @@ spec:
           args:
             - prepare_and_run make run
           envFrom:
+            # configMapRef is duplicated from the base because for some reason (kustomize bug?) it will disappear
+            # if we only set the secretRef here
             - configMapRef:
                 name: tpe-prebid-service-env
             - secretRef:

--- a/deploy/kubernetes/overlays/localdev/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/localdev/web-internal/kustomization.yaml
@@ -8,7 +8,7 @@ commonLabels:
   app.kubernetes.io/component: app
   app.kubernetes.io/managed-by: kustomize
   app.kubernetes.io/part-of: tpe_prebid_service
-  environment: development
+  ops.tapjoy.net/environment: development
 
 resources:
   - ../../../base
@@ -30,6 +30,7 @@ components:
 
 configMapGenerator:
   - name: tpe-prebid-service-env
+    behavior: merge
     literals:
       # Placeholder until we need some real ENV for the application
       - RACK_ENV="development"


### PR DESCRIPTION
This changeset runs successfully in EKS and a slug continues to build.

We are planning to add MBS back to production next. This means that the engineers deploying changes to this repo will now have 2 production approval phases. The first one is EKS-based Kubernetes infra, and the second one the EC2-based infra.