### PR TITLE
Increase limits in systemd template

### DIFF
--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 791ebe1234655b18aa6e361b1ffe42197539b8ae
+  newTag: 34aa9b48dab71832bfb4a2f0ec5d8d122c914c03
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/deploy/systemd-templates/process.service.erb
+++ b/deploy/systemd-templates/process.service.erb
@@ -1,0 +1,28 @@
+# This file is an override of the generic systemd process.service.erb template
+# found in slugforge-internal
+# The variables that are normall doubly escaped (`<%%=  %>`) for pre-processing
+# by slugforge have been normally escaped (`<%= %>`)
+# Any futher modification should conform to this pattern
+
+[Unit]
+Description=<%= app %>-<%= name %>[<%= num %>]
+# The process is part of the application target
+PartOf=<%= app %>.target
+
+[Service]
+# By default we assume we are working with a non-forking application (simple)
+# TODO: Forked processes (unicorn/etc.) may be able to do away with
+# using shepherd scripts in Systemd managed environments
+Type=simple
+User=<%= user %>
+WorkingDirectory=<%= engine.root %>
+ExecStart=/bin/bash -l -c 'cd <%= engine.root %>/current ; if [ -f <%= engine.root %>/shared/env ] ; then source <%= engine.root %>/shared/env ; fi ; if [ -f <%= engine.root %>/shared/env-export ] ; then source <%= engine.root %>/shared/env-export ; fi ; <%= process.command %> 2>&1 | setsid logger -t <%= app %>-<%= name %>[<%= num %>]'
+# Systemd starts processes in user shells that do not use PAM for login
+# so any per user /etc/security/limits.conf overrides are ignored
+# Explicitly up the file and process count to give deployboard's runner
+# a lot of resources to work with
+LimitNOFILE=100000
+LimitNPROC=100000
+Restart=always
+RestartSec=2s
+KillMode=mixed


### PR DESCRIPTION
Unfortunately systemd breaks previously-orthogonal relationships, and even though we set appropriate user limits in Chef systemd doesn't respect them.

From a prod box currently:

```
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:15:00.718336    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:15:00 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:15:00.723527    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:15:00 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:15:00.728699    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:15:00 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:15:00.736651    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:15:00 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:15:00 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:24:15.769090    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:24:15 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:24:15.776750    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:24:15 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:24:15.788062    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: 2022/03/04 00:24:15 http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 5ms
Mar  4 00:24:15 ip-172-16-10-216 tpe_prebid_service-web[1]: E0304 00:24:15.796905    6128 listener.go:44] Error accepting connection: accept tcp [::]:8000: accept4: too many open files
```