### PR TITLE
OPER-6066 Override otelcol endpoint

### DIFF
--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
@@ -25,7 +25,7 @@ spec:
             # TODO Remove env var overrides once app runs exclusively in k8s or the env vars are no longer published
             # PBS_ADAPTERS_TAPJOY_ENDPOINT setup is a gift for devs living in a future when optsoa runs in EKS
             - chamber exec devops/aws/production/tpe_prebid_service-web_internal/env --
-              env PBS_ADAPTERS_TAPJOY_ENDPOINT=http://legacy-discovery:7286/bid
+              env PBS_ADAPTERS_TAPJOY_ENDPOINT=http://legacy-discovery:7286/bid PBS_MONITORING_OPENTELEMETRY_ENDPOINT=otelcol-gateway.observability-system:4139
               ./tpe_prebid_service
           resources:
             requests:

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 34aa9b48dab71832bfb4a2f0ec5d8d122c914c03
+  newTag: cab7899e07b76680dbeb45c9f12c577314fa32f8
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
I missed this in the logs

```
2022/03/04 19:55:07 traces exporter is disconnected from the server localhost:4139: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:4139: connect: connection refused"
```