### PR TITLE
[NGS-829] Use mediator bid floor for Tapjoy DSP.

### DIFF
--- a/adapters/tapjoy/tapjoy.go
+++ b/adapters/tapjoy/tapjoy.go
@@ -101,6 +101,9 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 		// ensure correct value for request.imp[].displaymanager
 		thisImp.DisplayManager = "tapjoy_sdk"
 
+		// overwrite bid floor with mediator given bid floor
+		thisImp.BidFloor = tapjoyExt.Imp.BidFloor
+
 		// request.imp[].ext
 		thisImp.Ext = tapjoyExt.Extensions.ImpExt
 

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
@@ -34,13 +34,16 @@
         "displaymanagerver": "12.8.1",
         "instl": 1,
         "tagid": "4160260845",
-        "bidfloor": 0.01,
+        "bidfloor": 123.45,
         "bidfloorcur": "USD",
         "secure": 1,
         "ext": {
           "bidder": {
             "app": {
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
+            },
+            "imp": {
+              "bidfloor": 123.46
             },
             "device": {
               "os": "android",
@@ -263,7 +266,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 0.01,
+              "bidfloor": 123.46,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
@@ -34,13 +34,16 @@
         "displaymanagerver": "12.8.1",
         "instl": 1,
         "tagid": "4160260845",
-        "bidfloor": 0.01,
+        "bidfloor": 123.47,
         "bidfloorcur": "USD",
         "secure": 1,
         "ext": {
           "bidder": {
             "app": {
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
+            },
+            "imp": {
+              "bidfloor": 123.48
             },
             "device": {
               "os": "android",
@@ -263,7 +266,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 0.01,
+              "bidfloor": 123.48,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 0ed29df005ab4d37552dfb97e1179fceecec4817
+  newTag: a76b6b82f20cee9ba30108c1bd51ae8eaa476249
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/openrtb_ext/imp_tapjoy.go
+++ b/openrtb_ext/imp_tapjoy.go
@@ -7,6 +7,7 @@ import (
 // ExtImpTapjoy defines the contract for bidrequest.imp[i].ext.tapjoy
 type ExtImpTapjoy struct {
 	App        TJApp        `json:"app"`
+	Imp        TJImp        `json:"imp"`
 	Device     TJDevice     `json:"device"`
 	Request    TJRequest    `json:"request"`
 	Extensions TJExtensions `json:"extensions"`
@@ -19,6 +20,10 @@ type ExtImpTapjoy struct {
 
 type TJApp struct {
 	ID string `json:"id"`
+}
+
+type TJImp struct {
+	BidFloor float64 `json:"bidfloor"`
 }
 
 type TJDevice struct {


### PR DESCRIPTION
## Context

This PR adds support for the mediator bid floor to be used as the bid floor for Tapjoy DSP. The bid floor value is passed in the tapjoy imp extension object and is then extract and placed in the Tapjoy imp object.

## Jira

https://tapjoy.atlassian.net/browse/NGS-829

