### PR TITLE
[NGS-847] Enable OPTSOA to use BFS bid floor

### DIFF
--- a/adapters/tapjoy/tapjoy.go
+++ b/adapters/tapjoy/tapjoy.go
@@ -101,9 +101,6 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 		// ensure correct value for request.imp[].displaymanager
 		thisImp.DisplayManager = "tapjoy_sdk"
 
-		// overwrite bid floor with mediator given bid floor
-		thisImp.BidFloor = tapjoyExt.Imp.BidFloor
-
 		// request.imp[].ext
 		thisImp.Ext = tapjoyExt.Extensions.ImpExt
 

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
@@ -34,16 +34,13 @@
         "displaymanagerver": "12.8.1",
         "instl": 1,
         "tagid": "4160260845",
-        "bidfloor": 123.45,
+        "bidfloor": 0.01,
         "bidfloorcur": "USD",
         "secure": 1,
         "ext": {
           "bidder": {
             "app": {
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
-            },
-            "imp": {
-              "bidfloor": 123.46
             },
             "device": {
               "os": "android",
@@ -266,7 +263,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 123.46,
+              "bidfloor": 0.01,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
@@ -34,16 +34,13 @@
         "displaymanagerver": "12.8.1",
         "instl": 1,
         "tagid": "4160260845",
-        "bidfloor": 123.47,
+        "bidfloor": 0.01,
         "bidfloorcur": "USD",
         "secure": 1,
         "ext": {
           "bidder": {
             "app": {
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
-            },
-            "imp": {
-              "bidfloor": 123.48
             },
             "device": {
               "os": "android",
@@ -266,7 +263,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 123.48,
+              "bidfloor": 0.01,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: af1804d34e9a2c3a056293e3aee54d975a572a2e
+  newTag: 05e1eadbabb970638a67a9a08d8d47b29cf34a22
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/openrtb_ext/imp_tapjoy.go
+++ b/openrtb_ext/imp_tapjoy.go
@@ -7,7 +7,6 @@ import (
 // ExtImpTapjoy defines the contract for bidrequest.imp[i].ext.tapjoy
 type ExtImpTapjoy struct {
 	App        TJApp        `json:"app"`
-	Imp        TJImp        `json:"imp"`
 	Device     TJDevice     `json:"device"`
 	Request    TJRequest    `json:"request"`
 	Extensions TJExtensions `json:"extensions"`
@@ -20,10 +19,6 @@ type ExtImpTapjoy struct {
 
 type TJApp struct {
 	ID string `json:"id"`
-}
-
-type TJImp struct {
-	BidFloor float64 `json:"bidfloor"`
 }
 
 type TJDevice struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Context
Enabled OPTSOA to use BFS bid floor only

## PRs
TJX: https://github.com/Tapjoy/mediation_bid_service/pull/1211
TPE: https://github.com/Tapjoy/tpe_prebid_service/pull/120

 ## How Has This Been Tested?

 `make build` yields no errors

 ## Jira Link

Jira: https://tapjoy.atlassian.net/browse/NGS-847

