### PR TITLE
[NGS-833]  Add Multi Bidfloor Support For DSPs

### DIFF
--- a/adapters/aarki/aarki.go
+++ b/adapters/aarki/aarki.go
@@ -169,6 +169,11 @@ func (adapter *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.Ex
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if aarkiExt.BidFloor != nil {
+			thisImp.BidFloor = *aarkiExt.BidFloor
+		}
+
 		impExt := aarkiImpExt{}
 
 		// Add SKADN if supported and present

--- a/adapters/aarki/aarki_test.go
+++ b/adapters/aarki/aarki_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package aarki
 
 import (

--- a/adapters/appier/appier.go
+++ b/adapters/appier/appier.go
@@ -208,6 +208,11 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if appierExt.BidFloor != nil {
+			thisImp.BidFloor = *appierExt.BidFloor
+		}
+
 		impExt := appierImpExt{
 			Rewarded: rewarded,
 		}

--- a/adapters/appier/appier_test.go
+++ b/adapters/appier/appier_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package appier
 
 import (

--- a/adapters/dv360/dv360.go
+++ b/adapters/dv360/dv360.go
@@ -204,6 +204,11 @@ func (adapter *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.Ex
 			impCopy.Video = &videoCopy
 		}
 
+		// Overwrite BidFloor if present
+		if dv360Ext.BidFloor != nil {
+			impCopy.BidFloor = *dv360Ext.BidFloor
+		}
+
 		// create impression extension object
 		// Hardcode serverside to 1 as per external disc https://tapjoy.atlassian.net/browse/NGS-44
 		impExt := dv360ImpExt{

--- a/adapters/dv360/dv360_test.go
+++ b/adapters/dv360/dv360_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package dv360
 
 import (

--- a/adapters/kadenai/kadenai.go
+++ b/adapters/kadenai/kadenai.go
@@ -186,6 +186,11 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adapters.Ex
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if kadenaiExt.BidFloor != nil {
+			thisImp.BidFloor = *kadenaiExt.BidFloor
+		}
+
 		impExt := kadenaiImpExt{
 			Rewarded: rewarded,
 		}

--- a/adapters/kadenai/kadenai_test.go
+++ b/adapters/kadenai/kadenai_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package kadenai
 
 import (

--- a/adapters/liftoff/liftoff.go
+++ b/adapters/liftoff/liftoff.go
@@ -210,6 +210,10 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adapters.Ex
 				thisImp.Banner = nil
 			}
 		}
+		// Overwrite BidFloor if present
+		if liftoffExt.BidFloor != nil {
+			thisImp.BidFloor = *liftoffExt.BidFloor
+		}
 
 		impExt := liftoffImpExt{
 			Rewarded: rewarded,

--- a/adapters/liftoff/liftoff_test.go
+++ b/adapters/liftoff/liftoff_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package liftoff
 
 import (

--- a/adapters/moloco/moloco.go
+++ b/adapters/moloco/moloco.go
@@ -182,6 +182,11 @@ func (adapter *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.Ex
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if molocoExt.BidFloor != nil {
+			thisImp.BidFloor = *molocoExt.BidFloor
+		}
+
 		// Add impression extensions
 		impExt := molocoImpExt{}
 

--- a/adapters/moloco/moloco_test.go
+++ b/adapters/moloco/moloco_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package moloco
 
 import (

--- a/adapters/operaads/operaads.go
+++ b/adapters/operaads/operaads.go
@@ -182,6 +182,11 @@ func (a *OperaAdsAdapter) MakeRequests(
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if operaadsExt.BidFloor != nil {
+			imp.BidFloor = *operaadsExt.BidFloor
+		}
+
 		impExt := operaAdsImpExt{
 			Rewarded: rewarded,
 		}

--- a/adapters/operaads/operaads_test.go
+++ b/adapters/operaads/operaads_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package operaads
 
 import (

--- a/adapters/operaads/params_test.go
+++ b/adapters/operaads/params_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package operaads
 
 import (

--- a/adapters/operaads/usersync_test.go
+++ b/adapters/operaads/usersync_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package operaads
 
 import (

--- a/adapters/pangle/pangle.go
+++ b/adapters/pangle/pangle.go
@@ -129,6 +129,11 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			imp.Banner = nil
 		}
 
+		// Overwrite BidFloor if present
+		if bidderImpExt.BidFloor != nil {
+			imp.BidFloor = *bidderImpExt.BidFloor
+		}
+
 		if bidderImpExt.SKADNSupported {
 			skadn := adapters.FilterPrebidSKADNExt(impExt.Prebid, pangleExtSKADNetIDs)
 			// only add if present

--- a/adapters/pangle/pangle_test.go
+++ b/adapters/pangle/pangle_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package pangle
 
 import (

--- a/adapters/pangle/param_test.go
+++ b/adapters/pangle/param_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package pangle
 
 import (

--- a/adapters/personaly/personaly.go
+++ b/adapters/personaly/personaly.go
@@ -186,6 +186,11 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adapters.Ex
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if personalyExt.BidFloor != nil {
+			thisImp.BidFloor = *personalyExt.BidFloor
+		}
+
 		impExt := personalyImpExt{
 			Rewarded: rewarded,
 		}

--- a/adapters/personaly/personaly_test.go
+++ b/adapters/personaly/personaly_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package personaly
 
 import (

--- a/adapters/pubmatic/params_test.go
+++ b/adapters/pubmatic/params_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package pubmatic
 
 import (

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -193,16 +193,6 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 					pbReq.Imp[i].Banner.W = openrtb2.Int64Ptr(int64(width))
 					pbReq.Imp[i].Banner.H = openrtb2.Int64Ptr(int64(height))
 
-					// for usa requests -- set bidfloor to a min of 10.0 for RW, 8.00 for NonRW
-					if pbReq.Device != nil && pbReq.Device.Geo != nil && strings.ToLower(pbReq.Device.Geo.Country) == "usa" {
-						if pbReq.Imp[i].Video != nil && pbReq.Imp[i].Video.Skip != nil && *pbReq.Imp[i].Video.Skip == 0 && pbReq.Imp[i].BidFloor < 10.0 {
-							pbReq.Imp[i].BidFloor = 10.0
-						}
-						if pbReq.Imp[i].Video != nil && pbReq.Imp[i].Video.Skip != nil && *pbReq.Imp[i].Video.Skip == 1 && pbReq.Imp[i].BidFloor < 8.0 {
-							pbReq.Imp[i].BidFloor = 8.0
-						}
-					}
-
 					if len(params.Keywords) != 0 {
 						kvstr := prepareImpressionExt(params.Keywords)
 						pbReq.Imp[i].Ext = json.RawMessage([]byte(kvstr))
@@ -383,14 +373,9 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ad
 		return nil, errs
 	}
 
-	// for usa requests -- set bidfloor to a min of 10.0 for RW, 8.00 for NonRW
-	if request.Device != nil && request.Device.Geo != nil && strings.ToLower(request.Device.Geo.Country) == "usa" {
-		if impData.pubmatic.Reward == 1 && request.Imp[0].BidFloor < 10.0 {
-			request.Imp[0].BidFloor = 10.0
-		}
-		if impData.pubmatic.Reward != 1 && request.Imp[0].BidFloor < 8.0 {
-			request.Imp[0].BidFloor = 8.0
-		}
+	// Overwrite BidFloor if present
+	if impData.pubmatic.BidFloor != nil {
+		request.Imp[0].BidFloor = *impData.pubmatic.BidFloor
 	}
 
 	if wrapExt != "" {

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package pubmatic
 
 import (

--- a/adapters/pubmatic/pubmatictest/exemplary/dsp-based-bid-floor-banner.json
+++ b/adapters/pubmatic/pubmatictest/exemplary/dsp-based-bid-floor-banner.json
@@ -3,6 +3,7 @@
         "id": "test-request-id",
         "imp": [{
             "id": "test-imp-id",
+            "bidfloor":10.0,
             "banner": {
                 "format": [{
                     "w": 300,
@@ -26,7 +27,8 @@
                         "version": 1,
                         "profile": 5123
                     },
-                    "mraid_supported": true
+                    "mraid_supported": true,
+                    "bid_floor":100.0
                 }
             }
         }],
@@ -64,7 +66,8 @@
                 "ext": {
                   "pmZoneId": "Zone1,Zone2",
                   "preference": "sports,movies"
-                }
+                },
+                "bidfloor":100.0
               }
             ], 
             "device":{

--- a/adapters/pubmatic/usersync_test.go
+++ b/adapters/pubmatic/usersync_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package pubmatic
 
 import (

--- a/adapters/rtbhouse/rtbhouse.go
+++ b/adapters/rtbhouse/rtbhouse.go
@@ -177,6 +177,11 @@ func (adapter *RTBHouseAdapter) MakeRequests(
 			}
 		}
 
+		// Overwrite BidFloor if present
+		if rtbHouseExt.BidFloor != nil {
+			thisImp.BidFloor = *rtbHouseExt.BidFloor
+		}
+
 		impExt := rtbHouseImpExt{
 			Rewarded: rewarded,
 		}

--- a/adapters/rtbhouse/rtbhouse_test.go
+++ b/adapters/rtbhouse/rtbhouse_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rtbhouse
 
 import (

--- a/adapters/rtbhouse/usersync_test.go
+++ b/adapters/rtbhouse/usersync_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rtbhouse
 
 import (

--- a/adapters/rubicon/rubicon.go
+++ b/adapters/rubicon/rubicon.go
@@ -994,6 +994,11 @@ func (a *RubiconAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *ada
 			continue
 		}
 
+		// Overwrite BidFloor if present
+		if rubiconExt.BidFloor != nil {
+			thisImp.BidFloor = *rubiconExt.BidFloor
+		}
+
 		siteExt := rubiconSiteExt{RP: rubiconSiteExtRP{SiteID: rubiconExt.SiteId}}
 		pubExt := rubiconPubExt{RP: rubiconPubExtRP{AccountID: rubiconExt.AccountId}}
 

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rubicon
 
 import (

--- a/adapters/rubicon/usersync_test.go
+++ b/adapters/rubicon/usersync_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rubicon
 
 import (

--- a/adapters/rubiconmraid/rubiconmraid.go
+++ b/adapters/rubiconmraid/rubiconmraid.go
@@ -970,6 +970,11 @@ func (a *RubiconMRAIDAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo
 			continue
 		}
 
+		// Overwrite BidFloor if present
+		if rubiconExt.BidFloor != nil {
+			thisImp.BidFloor = *rubiconExt.BidFloor
+		}
+
 		siteExt := rubiconSiteExt{RP: rubiconSiteExtRP{SiteID: rubiconExt.SiteId}}
 		pubExt := rubiconPubExt{RP: rubiconPubExtRP{AccountID: rubiconExt.AccountId}}
 

--- a/adapters/rubiconmraid/rubiconmraid_test.go
+++ b/adapters/rubiconmraid/rubiconmraid_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rubiconmraid
 
 import (

--- a/adapters/rubiconmraid/usersync_test.go
+++ b/adapters/rubiconmraid/usersync_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package rubiconmraid
 
 import (

--- a/adapters/tapjoy/tapjoy.go
+++ b/adapters/tapjoy/tapjoy.go
@@ -104,6 +104,11 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 		// overwrite bid floor with mediator given bid floor
 		thisImp.BidFloor = tapjoyExt.Imp.BidFloor
 
+		// Overwrite BidFloor if present
+		if tapjoyExt.BidFloor != nil {
+			thisImp.BidFloor = *tapjoyExt.BidFloor
+		}
+
 		// request.imp[].ext
 		thisImp.Ext = tapjoyExt.Extensions.ImpExt
 

--- a/adapters/tapjoy/tapjoy_test.go
+++ b/adapters/tapjoy/tapjoy_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package tapjoy
 
 import (

--- a/adapters/taurusx/taurusx.go
+++ b/adapters/taurusx/taurusx.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prebid/prebid-server/config"
 	"net/http"
+
+	"github.com/prebid/prebid-server/config"
 
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
@@ -163,6 +164,11 @@ func (adapter *adapter) MakeRequests(request *openrtb2.BidRequest, _ *adapters.E
 			} else {
 				thisImp.Banner = nil
 			}
+		}
+
+		// Overwrite BidFloor if present
+		if taurusxExt.BidFloor != nil {
+			thisImp.BidFloor = *taurusxExt.BidFloor
 		}
 
 		impExt := taurusxImpExt{}

--- a/adapters/taurusx/taurusx_test.go
+++ b/adapters/taurusx/taurusx_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package taurusx
 
 import (

--- a/adapters/unicorn/params_test.go
+++ b/adapters/unicorn/params_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package unicorn
 
 import (

--- a/adapters/unicorn/unicorn.go
+++ b/adapters/unicorn/unicorn.go
@@ -166,6 +166,11 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, requestInfo *adapte
 			thisImp.Video = &videoCopy
 		}
 
+		// Overwrite BidFloor if present
+		if unicornExt.BidFloor != nil {
+			thisImp.BidFloor = *unicornExt.BidFloor
+		}
+
 		impExt := unicornImpExt{}
 
 		if unicornExt.SKADNSupported {

--- a/adapters/unicorn/unicorn_test.go
+++ b/adapters/unicorn/unicorn_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package unicorn
 
 import (

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: dc6ebd9809e77b62b4efe18cde4450c0f474b835
+  newTag: 8419918c599662a20176c4f90496627c9c2bc48c
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/openrtb_ext/imp_aarki.go
+++ b/openrtb_ext/imp_aarki.go
@@ -2,9 +2,10 @@ package openrtb_ext
 
 // ExtImpAarki defines the contract for bidrequest.imp[i].ext.aarki
 type ExtImpAarki struct {
-	Reward               int    `json:"reward"`
-	Region               string `json:"region"`          // this field added to support multiple aarki endpoints
-	SKADNSupported       bool   `json:"skadn_supported"` // enable skadn ext parameters
-	MRAIDSupported       bool   `json:"mraid_supported"`
-	EndcardHTMLSupported bool   `json:"endcard_html_supported"`
+	Reward               int      `json:"reward"`
+	Region               string   `json:"region"`          // this field added to support multiple aarki endpoints
+	SKADNSupported       bool     `json:"skadn_supported"` // enable skadn ext parameters
+	MRAIDSupported       bool     `json:"mraid_supported"`
+	EndcardHTMLSupported bool     `json:"endcard_html_supported"`
+	BidFloor             *float64 `json:"bid_floor,omitempty"`
 }

--- a/openrtb_ext/imp_appier.go
+++ b/openrtb_ext/imp_appier.go
@@ -7,6 +7,7 @@ type ExtImpAppier struct {
 	SKADNSupported       bool              `json:"skadn_supported"`
 	MRAIDSupported       bool              `json:"mraid_supported"`
 	EndcardHTMLSupported bool              `json:"endcard_html_supported"`
+	BidFloor             *float64          `json:"bid_floor,omitempty"`
 }
 
 // appierVideoParams defines the contract for bidrequest.imp[i].ext.appier.video

--- a/openrtb_ext/imp_dv360.go
+++ b/openrtb_ext/imp_dv360.go
@@ -1,10 +1,11 @@
 package openrtb_ext
 
 type ExtImpDV360 struct {
-	Region         string `json:"region"`
-	Reward         int    `json:"reward"`
-	SKADNSupported bool   `json:"skadn_supported"`
-	MRAIDSupported bool   `json:"mraid_supported"`
-	RawIP          string `json:"raw_ip"`
-	PubID          string `json:"pub_id"`
+	Region         string   `json:"region"`
+	Reward         int      `json:"reward"`
+	SKADNSupported bool     `json:"skadn_supported"`
+	MRAIDSupported bool     `json:"mraid_supported"`
+	RawIP          string   `json:"raw_ip"`
+	PubID          string   `json:"pub_id"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }

--- a/openrtb_ext/imp_kadenai.go
+++ b/openrtb_ext/imp_kadenai.go
@@ -5,6 +5,7 @@ type ExtImpKadenAI struct {
 	Video          kadenaiVideoParams `json:"video"`
 	SKADNSupported bool               `json:"skadn_supported"`
 	MRAIDSupported bool               `json:"mraid_supported"`
+	BidFloor       *float64           `json:"bid_floor,omitempty"`
 }
 
 // kadenaiVideoParams defines the contract for bidrequest.imp[i].ext.kadenai.video

--- a/openrtb_ext/imp_liftoff.go
+++ b/openrtb_ext/imp_liftoff.go
@@ -7,6 +7,7 @@ type ExtImpLiftoff struct {
 	SKADNSupported       bool               `json:"skadn_supported"`
 	MRAIDSupported       bool               `json:"mraid_supported"`
 	EndcardHTMLSupported bool               `json:"endcard_html_supported"`
+	BidFloor             *float64           `json:"bid_floor,omitempty"`
 }
 
 // liftoffVideoParams defines the contract for bidrequest.imp[i].ext.liftoff.video

--- a/openrtb_ext/imp_moloco.go
+++ b/openrtb_ext/imp_moloco.go
@@ -2,9 +2,10 @@ package openrtb_ext
 
 // ExtImpMoloco defines the contract for bidrequest.imp[i].ext.moloco
 type ExtImpMoloco struct {
-	PlacementType        string `json:"placementtype"`
-	Region               string `json:"region"`          // this field added to support multiple moloco endpoints
-	SKADNSupported       bool   `json:"skadn_supported"` // enable skadn ext parameters
-	MRAIDSupported       bool   `json:"mraid_supported"`
-	EndcardHTMLSupported bool   `json:"endcard_html_supported"`
+	PlacementType        string   `json:"placementtype"`
+	Region               string   `json:"region"`          // this field added to support multiple moloco endpoints
+	SKADNSupported       bool     `json:"skadn_supported"` // enable skadn ext parameters
+	MRAIDSupported       bool     `json:"mraid_supported"`
+	EndcardHTMLSupported bool     `json:"endcard_html_supported"`
+	BidFloor             *float64 `json:"bid_floor,omitempty"`
 }

--- a/openrtb_ext/imp_operaads.go
+++ b/openrtb_ext/imp_operaads.go
@@ -9,6 +9,7 @@ type ExtImpOperaAds struct {
 	MRAIDSupported bool                 `json:"mraid_supported"`
 	EndpointId     string               `json:"endpointId"`
 	PlacementId    operaAdsPlacementIds `json:"placementId"`
+	BidFloor       *float64             `json:"bid_floor,omitempty"`
 }
 
 // operaadsVideoParams defines the contract for bidrequest.imp[i].ext.operaads.video

--- a/openrtb_ext/imp_pangle.go
+++ b/openrtb_ext/imp_pangle.go
@@ -5,8 +5,9 @@ type ImpExtPangle struct {
 	AppID       string `json:"appid,omitempty"`
 	PlacementID string `json:"placementid,omitempty"`
 
-	Reward         int    `json:"reward"`
-	Region         string `json:"region"`
-	SKADNSupported bool   `json:"skadn_supported"`
-	MRAIDSupported bool   `json:"mraid_supported"`
+	Reward         int      `json:"reward"`
+	Region         string   `json:"region"`
+	SKADNSupported bool     `json:"skadn_supported"`
+	MRAIDSupported bool     `json:"mraid_supported"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }

--- a/openrtb_ext/imp_personaly.go
+++ b/openrtb_ext/imp_personaly.go
@@ -5,6 +5,7 @@ type ExtImpPersonaly struct {
 	Video          personalyVideoParams `json:"video"`
 	SKADNSupported bool                 `json:"skadn_supported"`
 	MRAIDSupported bool                 `json:"mraid_supported"`
+	BidFloor       *float64             `json:"bid_floor,omitempty"`
 }
 
 // personalyVideoParams defines the contract for bidrequest.imp[i].ext.personaly.video

--- a/openrtb_ext/imp_pubmatic.go
+++ b/openrtb_ext/imp_pubmatic.go
@@ -16,11 +16,12 @@ type ExtImpPubmatic struct {
 	WrapExt     json.RawMessage         `json:"wrapper,omitempty"`
 	Keywords    []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
 
-	Reward         int    `json:"reward"`
-	SiteID         int    `json:"site_id"`
-	Region         string `json:"region"`
-	SKADNSupported bool   `json:"skadn_supported"`
-	MRAIDSupported bool   `json:"mraid_supported"`
+	Reward         int      `json:"reward"`
+	SiteID         int      `json:"site_id"`
+	Region         string   `json:"region"`
+	SKADNSupported bool     `json:"skadn_supported"`
+	MRAIDSupported bool     `json:"mraid_supported"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }
 
 // ExtImpPubmaticKeyVal defines the contract for bidrequest.imp[i].ext.pubmatic.keywords[i]

--- a/openrtb_ext/imp_rtbhouse.go
+++ b/openrtb_ext/imp_rtbhouse.go
@@ -7,6 +7,7 @@ type ExtImpRTBHouse struct {
 	Region         string              `json:"region"`
 	SKADNSupported bool                `json:"skadn_supported"`
 	MRAIDSupported bool                `json:"mraid_supported"`
+	BidFloor       *float64            `json:"bid_floor,omitempty"`
 }
 
 // rtbHouseVideoParams defines the contract for bidrequest.imp[i].ext.rtbhouse.video

--- a/openrtb_ext/imp_rubicon.go
+++ b/openrtb_ext/imp_rubicon.go
@@ -18,6 +18,7 @@ type ExtImpRubicon struct {
 	ViewabilityVendors []string `json:"viewabilityvendors"`
 	SKADNSupported     bool     `json:"skadn_supported"`
 	MRAIDSupported     bool     `json:"mraid_supported"`
+	BidFloor           *float64 `json:"bid_floor,omitempty"`
 }
 
 // rubiconVideoParams defines the contract for bidrequest.imp[i].ext.rubicon.video

--- a/openrtb_ext/imp_tapjoy.go
+++ b/openrtb_ext/imp_tapjoy.go
@@ -12,10 +12,11 @@ type ExtImpTapjoy struct {
 	Request    TJRequest    `json:"request"`
 	Extensions TJExtensions `json:"extensions"`
 
-	Region         string `json:"region"`
-	Reward         int    `json:"reward"`
-	SKADNSupported bool   `json:"skadn_supported"`
-	MRAIDSupported bool   `json:"mraid_supported"`
+	Region         string   `json:"region"`
+	Reward         int      `json:"reward"`
+	SKADNSupported bool     `json:"skadn_supported"`
+	MRAIDSupported bool     `json:"mraid_supported"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }
 
 type TJApp struct {

--- a/openrtb_ext/imp_taurusx.go
+++ b/openrtb_ext/imp_taurusx.go
@@ -2,8 +2,9 @@ package openrtb_ext
 
 // ExtImpTaurusX defines the contract for bidrequest.imp[i].ext.taurusx
 type ExtImpTaurusX struct {
-	Reward         int    `json:"reward"`
-	Region         string `json:"region"`          // this field added to support multiple taurusx endpoints
-	SKADNSupported bool   `json:"skadn_supported"` // enable skadn ext parameters
-	MRAIDSupported bool   `json:"mraid_supported"`
+	Reward         int      `json:"reward"`
+	Region         string   `json:"region"`          // this field added to support multiple taurusx endpoints
+	SKADNSupported bool     `json:"skadn_supported"` // enable skadn ext parameters
+	MRAIDSupported bool     `json:"mraid_supported"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }

--- a/openrtb_ext/imp_unicorn.go
+++ b/openrtb_ext/imp_unicorn.go
@@ -7,8 +7,9 @@ type ExtImpUnicorn struct {
 	MediaID     string `json:"mediaId"`
 	AccountID   int    `json:"accountId"`
 
-	Reward         int    `json:"reward,omitempty"`
-	Region         string `json:"region,omitempty"`
-	SKADNSupported bool   `json:"skadn_supported,omitempty"`
-	MRAIDSupported bool   `json:"mraid_supported,omitempty"`
+	Reward         int      `json:"reward,omitempty"`
+	Region         string   `json:"region,omitempty"`
+	SKADNSupported bool     `json:"skadn_supported,omitempty"`
+	MRAIDSupported bool     `json:"mraid_supported,omitempty"`
+	BidFloor       *float64 `json:"bid_floor,omitempty"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Context

We want to add support for multiple bid floors. Multi Bid Floor was previously handled in TPE Prebid, but we want to move this logic into MBS/TJX. 

Updated structs to support new bid floor fields 
Added support for multi bid floor traffic features
Updated tests to include new bid floor field

TPE Specific Changes:
Removed Pubmatic Multi Bid Floor handling and migrated into MBS/TJX
Overwrite the main imp bidfloor if multi bidfloor is present in the DSP imp ext

 ## How To Test

`make build` and `make test`
./validate.sh
End to end testing

 ## How Has This Been Tested?

`make build` and `make test`
./validate.sh
End to end testing

## Related PRs

Go Prebid: https://github.com/Tapjoy/go-prebid/pull/91
MBS: https://github.com/Tapjoy/mediation_bid_service/pull/1217
AS: https://github.com/Tapjoy/ad_service/pull/1030
TPEPS: https://github.com/Tapjoy/tpe_prebid_service/pull/122

 ## Jira Link

Jira: https://tapjoy.atlassian.net/browse/NGS-833

