### PR TITLE
OPER-5261 Increase termination grace period

### DIFF
--- a/deploy/kubernetes/base/app.yaml
+++ b/deploy/kubernetes/base/app.yaml
@@ -27,6 +27,7 @@ spec:
       maxUnavailable: 0 # We must *always* be at/above HPA-determined capacity so we will roll out by *first* scaling up
   template:
     spec:
+      terminationGracePeriodSeconds: 60 # Default 30, override as desired in overlay
       securityContext:
         fsGroup: 65534
         sysctls:

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/app-patch.yaml
@@ -50,10 +50,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command:
-                  - sh
-                  - -c
-                  - sleep 30
+                command: ["sleep", "30"]
           # Introduce a delay to the shutdown sequence to wait for the
           # pod to be taken out of Service backends.
           ## https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
@@ -65,7 +62,4 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command:
-                  - sh
-                  - -c
-                  - sleep 30 && /usr/sbin/nginx -s quit
+                command: ["sh", "-c", "sleep 30 && /usr/sbin/nginx -s quit"]

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 07f7f44ed6a7b7b269fe26297960ef5e07cc2aed
+  newTag: dc6ebd9809e77b62b4efe18cde4450c0f474b835
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
The default is 30, which creates a race condition between our standard lifecycle routines that involve a `sleep 30`.

Also including some readability fixes around lifecycle routines.