### PR TITLE
[NGS-887] Move Tapjoy Logic Into DSP Bid Floor Support

### DIFF
--- a/adapters/tapjoy/tapjoy.go
+++ b/adapters/tapjoy/tapjoy.go
@@ -101,9 +101,6 @@ func (a *adapter) MakeRequests(request *openrtb.BidRequest, _ *adapters.ExtraReq
 		// ensure correct value for request.imp[].displaymanager
 		thisImp.DisplayManager = "tapjoy_sdk"
 
-		// overwrite bid floor with mediator given bid floor
-		thisImp.BidFloor = tapjoyExt.Imp.BidFloor
-
 		// Overwrite BidFloor if present
 		if tapjoyExt.BidFloor != nil {
 			thisImp.BidFloor = *tapjoyExt.BidFloor

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded.json
@@ -43,7 +43,7 @@
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
             },
             "imp": {
-              "bidfloor": 123.46
+              "bidfloor": 123.45
             },
             "device": {
               "os": "android",
@@ -266,7 +266,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 123.46,
+              "bidfloor": 123.45,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
+++ b/adapters/tapjoy/tapjoytest/exemplary/video_rewarded_with_nbr.json
@@ -43,7 +43,7 @@
               "id": "6f07dc3a-3708-4a81-b6ca-680464788bbc"
             },
             "imp": {
-              "bidfloor": 123.48
+              "bidfloor": 123.47
             },
             "device": {
               "os": "android",
@@ -266,7 +266,7 @@
               "displaymanagerver": "12.8.1",
               "instl": 1,
               "tagid": "4160260845",
-              "bidfloor": 123.48,
+              "bidfloor": 123.47,
               "bidfloorcur": "USD",
               "secure": 1,
               "ext": {

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 9fc2208fca26ea7c55ba644a657948d42885c05b
+  newTag: babccbdbc2c4c418c0d23540552f1d84ce99c6f8
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/openrtb_ext/imp_tapjoy.go
+++ b/openrtb_ext/imp_tapjoy.go
@@ -7,7 +7,6 @@ import (
 // ExtImpTapjoy defines the contract for bidrequest.imp[i].ext.tapjoy
 type ExtImpTapjoy struct {
 	App        TJApp        `json:"app"`
-	Imp        TJImp        `json:"imp"`
 	Device     TJDevice     `json:"device"`
 	Request    TJRequest    `json:"request"`
 	Extensions TJExtensions `json:"extensions"`
@@ -21,10 +20,6 @@ type ExtImpTapjoy struct {
 
 type TJApp struct {
 	ID string `json:"id"`
-}
-
-type TJImp struct {
-	BidFloor float64 `json:"bidfloor"`
 }
 
 type TJDevice struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Context

Cleanup PR to remove deprecated Tapjoy bid floor logic that existed before NGS-833 DSP Bid Floor change.

 ## How To Test

`make build` and `./validate.sh`
local end to end testing to make sure bid floor values come through for Tapjoy bidder

 ## How Has This Been Tested?
`make build` and `./validate.sh`
end to end testing


 ## Jira Link

Jira: https://tapjoy.atlassian.net/browse/NGS-887

 ## Related PRs
Go Prebid: https://github.com/Tapjoy/go-prebid/pull/93
TPE: https://github.com/Tapjoy/tpe_prebid_service/pull/127/files
MBS: https://github.com/Tapjoy/mediation_bid_service/pull/1241

