### PR TITLE
[NO-JIRA] Update Otel Sampler Logic

### DIFF
--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 019ae476880509de9b9cd662ac79d5dffbadd03b
+  newTag: ba893bdef641944c754fe5740434db137b3e4a46
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest

--- a/opentelemetry.go
+++ b/opentelemetry.go
@@ -48,10 +48,13 @@ func initProvider(cfg config.OpenTelemetry) (DoneCallback, error) {
 	if err != nil {
 		return func() {}, err
 	}
+	// Not using ratio based sampler for now. Composite tries parent and defaults to 0.
+	ratioBasedSampler := sdktrace.TraceIDRatioBased(0.0)
+	compositeBasedSampler := sdktrace.ParentBased(ratioBasedSampler)
 
 	bsp := sdktrace.NewBatchSpanProcessor(exp)
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(cfg.SampleRate)),
+		sdktrace.WithSampler(compositeBasedSampler),
 		sdktrace.WithResource(res),
 		sdktrace.WithSpanProcessor(bsp),
 	)


### PR DESCRIPTION
Honeycomb logging was missing root spans for requests. After looking into this, we theorized that the Otel sampling logic for TJX and TPE might be causing noop root spans to propogate down from TJX to TPE. Noop spans were not handled correctly in TPE and created independent child spans to be created with missing parent spans.

With this change, we updated TPE to use composite based logic. TPE tries creating a child span from the parent span, and if that does not exist, will default back to ratio based logic with ratio set to 0.0.