### PR TITLE
[NGS-920] OperaAds banner sizes

### DIFF
--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 1f85081160cbf0e9d76976a81ecb10b7df727c46
+  newTag: e3125eda2ff9999179886a87a5da7ae9ac2c3f55
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
## JIRA
https://tapjoy.atlassian.net/browse/NGS-920

## Description
This PR is to overwrite OperaAds' Banner W & H with the default values that they provided:
- Phone: 320x480 (V), 480x320 (H)
- Tablet: 768x1024 (V), 1024x768 (H)

## How to Test
- [Phone/Horizontal](https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/m6PSzdCicNe/trace/58Cs8Vy1RyV?span=8fe7e26e3e461e30)
- [Tablet/Horizontal](https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/m6PSzdCicNe/trace/51TwCaZLhAm?span=a3d18c6eb87d7277)
- [Tablet/Vertical](https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/dWgLf6xPhcX/trace/GcuD4iZAW2c?span=7fd937852a4ddffe)
- [Phone/Vertical](https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/p4EXwuEuPXK/trace/t3J7Q6xHj3r?span=e50b27a43b1b1638)

Please check banner W and H of an OperaAds request, and also confirm it's not changing for other DSPs