### PR TITLE
[NGS-931] Added rewarded flag to video extensions

### DIFF
--- a/adapters/tjx_operaads/operaads.go
+++ b/adapters/tjx_operaads/operaads.go
@@ -28,6 +28,7 @@ type operaAdsVideoExt struct {
 	Orientation   string `json:"orientation"`
 	Skip          int    `json:"skip"`
 	SkipDelay     int    `json:"skipdelay"`
+	Rewarded      int    `json:"rewarded"`
 }
 
 type operaAdsBannerExt struct {
@@ -163,6 +164,7 @@ func (a *OperaAdsAdapter) MakeRequests(
 				Orientation:   string(orientation),
 				Skip:          operaadsExt.Video.Skip,
 				SkipDelay:     operaadsExt.Video.SkipDelay,
+				Rewarded:      rewarded,
 			}
 			videoCopy.Ext, err = json.Marshal(&videoExt)
 			if err != nil {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_apac.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_apac.json
@@ -120,7 +120,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 }
               },
               "ext": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_empty.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_empty.json
@@ -119,7 +119,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 }
               },
               "ext": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_eu.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_eu.json
@@ -121,7 +121,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 }
               },
               "ext": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_not_supported.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_not_supported.json
@@ -121,7 +121,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 }
               },
               "ext": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_us_east.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_us_east.json
@@ -121,7 +121,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 }
               },
               "ext": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/orientation_horizontal.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/orientation_horizontal.json
@@ -106,7 +106,8 @@
                   "orientation": "h",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 },
                 "linearity": 1,
                 "placement": 2,

--- a/adapters/tjx_operaads/operaadstest/exemplary/orientation_vertical.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/orientation_vertical.json
@@ -106,7 +106,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 },
                 "linearity": 1,
                 "placement": 2,

--- a/adapters/tjx_operaads/operaadstest/exemplary/video.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video.json
@@ -106,7 +106,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 },
                 "linearity": 1,
                 "placement": 2,

--- a/adapters/tjx_operaads/operaadstest/exemplary/video_interstitial.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video_interstitial.json
@@ -106,7 +106,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 },
                 "linearity": 1,
                 "placement": 2,

--- a/adapters/tjx_operaads/operaadstest/exemplary/video_rewarded.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video_rewarded.json
@@ -106,7 +106,8 @@
                   "orientation": "v",
                   "placementtype": "interstitial",
                   "skip": 1,
-                  "skipdelay": 5
+                  "skipdelay": 5,
+                  "rewarded": 0
                 },
                 "linearity": 1,
                 "placement": 2,

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 9eb7cf218b4d96b7a2bdb1a9aea234ad990a15d1
+  newTag: 924619938ab71a84c5900eaf051787af327f11e4
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Context
Passing Rewarded Flag in video extension 


 ## How Has This Been Tested?

`./validate.sh` and `make build` yield no error
HC: https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/HxreZWEWwP8/trace/w34KR2nRYEV?span=d8264179427496c5

 ## Jira Link

Jira: https://tapjoy.atlassian.net/browse/NGS-931

