### PR TITLE
[NGS-931] Removed rewarded from imp ext

### DIFF
--- a/adapters/tjx_operaads/operaads.go
+++ b/adapters/tjx_operaads/operaads.go
@@ -37,8 +37,7 @@ type operaAdsBannerExt struct {
 }
 
 type operaAdsImpExt struct {
-	Rewarded int                `json:"rewarded"`
-	SKADN    *openrtb_ext.SKADN `json:"skadn,omitempty"`
+	SKADN *openrtb_ext.SKADN `json:"skadn,omitempty"`
 }
 
 // Orientation ...
@@ -205,9 +204,7 @@ func (a *OperaAdsAdapter) MakeRequests(
 			imp.BidFloor = *operaadsExt.BidFloor
 		}
 
-		impExt := operaAdsImpExt{
-			Rewarded: rewarded,
-		}
+		impExt := operaAdsImpExt{}
 
 		// Add SKADN if supported and present
 		if operaadsExt.SKADNSupported {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_apac.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_apac.json
@@ -124,9 +124,7 @@
                   "rewarded": 0
                 }
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_empty.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_empty.json
@@ -123,9 +123,7 @@
                   "rewarded": 0
                 }
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_eu.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_eu.json
@@ -125,9 +125,7 @@
                   "rewarded": 0
                 }
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_not_supported.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_not_supported.json
@@ -125,9 +125,7 @@
                   "rewarded": 0
                 }
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/endpoint_us_east.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/endpoint_us_east.json
@@ -125,9 +125,7 @@
                   "rewarded": 0
                 }
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/orientation_horizontal.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/orientation_horizontal.json
@@ -114,9 +114,7 @@
                 "minbitrate": 10,
                 "maxbitrate": 10
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/orientation_vertical.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/orientation_vertical.json
@@ -114,9 +114,7 @@
                 "minbitrate": 10,
                 "maxbitrate": 10
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/video.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video.json
@@ -114,9 +114,7 @@
                 "minbitrate": 10,
                 "maxbitrate": 10
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/video_interstitial.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video_interstitial.json
@@ -114,9 +114,7 @@
                 "minbitrate": 10,
                 "maxbitrate": 10
               },
-              "ext": {
-                "rewarded" : 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/exemplary/video_rewarded.json
+++ b/adapters/tjx_operaads/operaadstest/exemplary/video_rewarded.json
@@ -114,9 +114,7 @@
                 "minbitrate": 10,
                 "maxbitrate": 10
               },
-              "ext": {
-                "rewarded": 0
-              }
+              "ext": {}
             }
           ],
           "device": {

--- a/adapters/tjx_operaads/operaadstest/supplemental/status_204.json
+++ b/adapters/tjx_operaads/operaadstest/supplemental/status_204.json
@@ -52,9 +52,7 @@
             {
               "id": "some-imp-id:opa:video",
               "tagid": "v00000",
-              "ext": {
-                "rewarded":0
-              },
+              "ext": {},
               "native": {
                 "request": "{\"native\":{\"ver\":\"1.1\",\"layout\":3,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":344,\"hmin\":194}},{\"id\":3,\"required\":1,\"img\":{\"type\":1,\"w\":128,\"wmin\":80,\"h\":128,\"hmin\":80}},{\"id\":4,\"required\":1,\"data\":{\"type\":2,\"len\":90}},{\"id\":6,\"data\":{\"type\":12,\"len\":15}}]}}",
                 "ver": "1.1"

--- a/adapters/tjx_operaads/operaadstest/supplemental/status_205.json
+++ b/adapters/tjx_operaads/operaadstest/supplemental/status_205.json
@@ -52,9 +52,7 @@
             {
               "id":"some-imp-id:opa:video",
               "tagid":"v00000",
-              "ext":{
-                "rewarded":0
-              },
+              "ext":{},
               "native":{
                 "request":"{\"native\":{\"ver\":\"1.1\",\"layout\":3,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":344,\"hmin\":194}},{\"id\":3,\"required\":1,\"img\":{\"type\":1,\"w\":128,\"wmin\":80,\"h\":128,\"hmin\":80}},{\"id\":4,\"required\":1,\"data\":{\"type\":2,\"len\":90}},{\"id\":6,\"data\":{\"type\":12,\"len\":15}}]}}",
                 "ver":"1.1"

--- a/adapters/tjx_operaads/operaadstest/supplemental/status_400.json
+++ b/adapters/tjx_operaads/operaadstest/supplemental/status_400.json
@@ -52,9 +52,7 @@
             {
               "id":"some-imp-id:opa:video",
               "tagid":"v00000",
-              "ext":{
-                "rewarded": 0
-              },
+              "ext":{},
               "native":{
                 "request":"{\"native\":{\"ver\":\"1.1\",\"layout\":3,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":90}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":344,\"hmin\":194}},{\"id\":3,\"required\":1,\"img\":{\"type\":1,\"w\":128,\"wmin\":80,\"h\":128,\"hmin\":80}},{\"id\":4,\"required\":1,\"data\":{\"type\":2,\"len\":90}},{\"id\":6,\"data\":{\"type\":12,\"len\":15}}]}}",
                 "ver":"1.1"

--- a/deploy/kubernetes/base/app.yaml
+++ b/deploy/kubernetes/base/app.yaml
@@ -24,7 +24,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       # TODO Set back to 33% before cutting back over to EKS
-      maxSurge: "1"
+      maxSurge: 1
       # TODO Set back to 15% before cutting back over to EKS
       maxUnavailable: "100%" # We must *always* be at/above HPA-determined capacity so we will roll out by *first* scaling up
   template:

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 924619938ab71a84c5900eaf051787af327f11e4
+  newTag: f2e57b6dae0522ba08396d1c38be358804f19665
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
## Description

On the request from Operaads removed rewarded from imp -> ext. 

## How this has been tested
`make build` and `./validate.sh` yields no error.
HC: https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/f3GouozBEju/trace/jZLVGc8593d?span=d9c0fb55590bbb8a

##Jira
https://tapjoy.atlassian.net/browse/NGS-931