### PR TITLE
[NGS-1081] Fixed Liftoff bid response extension

### DIFF
--- a/adapters/tjx_liftoff/liftoff.go
+++ b/adapters/tjx_liftoff/liftoff.go
@@ -77,7 +77,28 @@ type reqSourceExt struct {
 	HeaderBidding int `json:"header_bidding,omitempty"`
 }
 type liftoffBidExt struct {
-	AuctionID string `json:"auction_id,omitempty"`
+	SKADN       RespSKADN `json:"skadn,omitempty"` // prebid shared
+	AuctionID   string    `json:"auction_id,omitempty"`
+	Imptrackers []string  `json:"imptrackers,omitempty"`
+}
+
+// RespSKADN ...
+type RespSKADN struct {
+	Version    string     `json:"version"`    // Version of SKAdNetwork desired. Must be 2.0 or above.
+	Network    string     `json:"network"`    // Ad network identifier used in signature. Should match one of the items in the skadnetids array in the request
+	Campaign   string     `json:"campaign"`   // Campaign ID compatible with Apple’s spec. As of 2.0, should be an integer between 1 and 100, expressed as a string
+	ITunesItem string     `json:"itunesitem"` // ID of advertiser’s app in Apple’s app store. Should match BidResponse.bid.bundle
+	Nonce      string     `json:"nonce"`      // An id unique to each ad response
+	SourceApp  string     `json:"sourceapp"`  // ID of publisher’s app in Apple’s app store. Should match BidRequest.imp.ext.skad.sourceapp
+	Timestamp  string     `json:"timestamp"`  // Unix time in millis string used at the time of signature
+	Signature  string     `json:"signature"`  // SKAdNetwork signature as specified by Apple
+	Fidelities []Fidelity `json:"fidelities"` // Supports multiple fidelity types introduced in SKAdNetwork v2.2
+}
+type Fidelity struct {
+	Fidelity  int    `json:"fidelity"`  // The fidelity-type of the attribution to track
+	Signature string `json:"signature"` // SKAdNetwork signature as specified by Apple
+	Nonce     string `json:"nonce"`     // An id unique to each ad response
+	Timestamp string `json:"timestamp"` // Unix time in millis string used at the time of signature
 }
 
 type reqExt struct {

--- a/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/legacy-production-eks/web-internal/kustomization.yaml
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: app
   newName: localhost:5000/tapjoy/tpe_prebid_service
-  newTag: 6a14e52e065d9411188ed21fbed6f3a5132ab586
+  newTag: 1d405596afc72f84b5cc6acaa1a22e7e2efa7a50
 - name: nginx
   newName: localhost:5000/tapjoy/nginx
   newTag: latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Context

Passed Bid Response extension correctly while unmarshalling the bid response extensions.

 ## How Has This Been Tested?

`./validate.sh` and `make build` yields no error
HC: https://ui.honeycomb.io/tapjoy/datasets/mediation-bid-service/result/i5J9HXGXN29/trace/3rKjGTJsevC?fields[]=c_name&span=2dc0f1d00129b9df

 ## Jira Link

Jira: https://tapjoy.atlassian.net/browse/NGS-1081

